### PR TITLE
fix: resource spelling in docs

### DIFF
--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -8,9 +8,9 @@ kudoctl is the official cli client implementation for kudo.
 
 **Workload :** A definition of a task (executable/virtual machine/container) to execute.
 
-**Ressource :** A definition of a user or a workload, something that can be defined and sent to the kudo controller.
+**Resource :** A definition of a user or a workload, something that can be defined and sent to the kudo controller.
 
-**Instance :** A ressource that has been applied to the kudo nodes/cluster, example : an instance of a container workload is representing the container running with the arguments of the workload definition.
+**Instance :** A resource that has been applied to the kudo nodes/cluster, example : an instance of a container workload is representing the container running with the arguments of the workload definition.
 
 ## Configuration 
 
@@ -260,7 +260,7 @@ Create a resource definition and instanciate it. By default if a resource with t
 | --no-update |           | bool   | false        | If the resource already exists, don’t update it         |
 | --name      |           | string | `""`         | set the name of the resource                            |
 | --help      | -h        |        | false        | show help of the function.                              |
-| --kind      | -k        | string | `"workload"` | set the kind of the ressource to create and instanciate |
+| --kind      | -k        | string | `"workload"` | set the kind of the resource to create and instanciate |
 
 **Kind specific flags :**
 

--- a/docs/proposals/resource.md
+++ b/docs/proposals/resource.md
@@ -1,6 +1,6 @@
 # Resource schema
 
-A schema that can be sent to the controller in order to create a ressource.
+A schema that can be sent to the controller in order to create a resource.
 
 The schema is sent as JSON to the controller. When passed as a file to the client the resource is using the YAML format with an added top level property `api_version` setting which specifies the version of the controller api to use.
 
@@ -18,13 +18,13 @@ Example :
 
 **type :** string  
 
-Name of the ressource.
+Name of the resource.
 
 ## kind
 
 **type :** string
 
-Type of the ressource :
+Type of the resource :
 
 - `workload` : see [workload.md](./workload.md).
 - `user` : will be used for the creation of an user, the definition is not expected in v0.

--- a/docs/proposals/workload.md
+++ b/docs/proposals/workload.md
@@ -8,7 +8,7 @@ Example :
     "type": "container",
     "name": "test-workload",
     "uri": "nginx",
-    "ressources": {
+    "resources": {
         "cpu": 1.0,
         "ram": 2048,
         "disk": 2,
@@ -43,25 +43,25 @@ Name of the workload, should be unique in the controller’s database.
 
 The name/uri of the container image , or an URI to the vm image or binary executable.
 
-## ressources
+## resources
 
 **type :** object/struct
 
-Definition of the maximum (container, binary) or allocated (vm) ressources.
+Definition of the maximum (container, binary) or allocated (vm) resources.
 
-### ressources.cpu
+### resources.cpu
 
 **type :** integer
 
 CPU usage, in number of milliCPU allocated.
 
-### ressources.ram
+### resources.ram
 
 **type :** integer
 
 Memory amount, unit is MB.
 
-### ressources.disk
+### resources.disk
 
 **type :** integer
 


### PR DESCRIPTION
Resource is spelled wrongly.
This pull request changes every misspelled "ressource" into "resource".