### PR TITLE
feat: add base scheduler application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,9 @@ dependencies = [
  "env_logger 0.8.4",
  "log",
  "proto",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,19 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
@@ -1455,6 +1468,8 @@ dependencies = [
 name = "scheduler"
 version = "0.1.0"
 dependencies = [
+ "env_logger 0.8.4",
+ "log",
  "proto",
 ]
 

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 proto = { path = "../proto" }
+log = "0.4.0"
+env_logger = "0.8.4"

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 proto = { path = "../proto" }
 log = "0.4.0"
 env_logger = "0.8.4"
+tonic = "0.7.2"
+tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
+tokio-stream = { version = "0.1", features = ["net"] }

--- a/scheduler/src/instance_listener.rs
+++ b/scheduler/src/instance_listener.rs
@@ -7,8 +7,18 @@ use proto::scheduler::{
     instance_service_server::InstanceService, Instance, InstanceIdentifier, InstanceStatus,
 };
 
-#[derive(Debug, Default)]
-pub struct InstanceListener {}
+use crate::{manager::Manager, Event};
+
+#[derive(Debug)]
+pub struct InstanceListener {
+    sender: mpsc::Sender<Event>,
+}
+
+impl InstanceListener {
+    pub fn new(sender: mpsc::Sender<Event>) -> Self {
+        InstanceListener { sender }
+    }
+}
 
 #[tonic::async_trait]
 impl InstanceService for InstanceListener {
@@ -16,29 +26,76 @@ impl InstanceService for InstanceListener {
         &self,
         request: Request<Instance>,
     ) -> Result<Response<Self::CreateStream>, Status> {
-        debug!("{:?}", request);
+        debug!("received request: {:?}", request);
+        let (tx, rx) = Manager::create_mpsc_channel();
 
-        let (tx, rx) = mpsc::channel(4);
-        Ok(Response::new(ReceiverStream::new(rx)))
+        match self
+            .sender
+            .send(Event::InstanceCreate(request.into_inner(), tx))
+            .await
+        {
+            Ok(_) => {
+                return Ok(Response::new(ReceiverStream::new(rx)));
+            }
+            Err(_) => {
+                return Err(Status::internal("could not send event to manager"));
+            }
+        }
     }
 
     type CreateStream = ReceiverStream<Result<InstanceStatus, Status>>;
 
     async fn start(&self, request: Request<InstanceIdentifier>) -> Result<Response<()>, Status> {
-        debug!("{:?}", request);
+        debug!("received request: {:?}", request);
+        let (tx, rx) = Manager::create_oneshot_channel();
 
-        Ok(Response::new(()))
+        match self
+            .sender
+            .send(Event::InstanceStart(request.into_inner().id, tx))
+            .await
+        {
+            Ok(_) => {
+                return rx.await.unwrap();
+            }
+            Err(_) => {
+                return Err(Status::internal("could not send event to manager"));
+            }
+        }
     }
 
     async fn stop(&self, request: Request<InstanceIdentifier>) -> Result<Response<()>, Status> {
-        debug!("{:?}", request);
+        debug!("received request: {:?}", request);
+        let (tx, rx) = Manager::create_oneshot_channel();
 
-        Ok(Response::new(()))
+        match self
+            .sender
+            .send(Event::InstanceStop(request.into_inner().id, tx))
+            .await
+        {
+            Ok(_) => {
+                return rx.await.unwrap();
+            }
+            Err(_) => {
+                return Err(Status::internal("could not send event to manager"));
+            }
+        }
     }
 
     async fn destroy(&self, request: Request<InstanceIdentifier>) -> Result<Response<()>, Status> {
-        debug!("{:?}", request);
+        debug!("received request: {:?}", request);
+        let (tx, rx) = Manager::create_oneshot_channel();
 
-        Ok(Response::new(()))
+        match self
+            .sender
+            .send(Event::InstanceDestroy(request.into_inner().id, tx))
+            .await
+        {
+            Ok(_) => {
+                return rx.await.unwrap();
+            }
+            Err(_) => {
+                return Err(Status::internal("could not send event to manager"));
+            }
+        }
     }
 }

--- a/scheduler/src/instance_listener.rs
+++ b/scheduler/src/instance_listener.rs
@@ -1,0 +1,44 @@
+use log::debug;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use proto::scheduler::{
+    instance_service_server::InstanceService, Instance, InstanceIdentifier, InstanceStatus,
+};
+
+#[derive(Debug, Default)]
+pub struct InstanceListener {}
+
+#[tonic::async_trait]
+impl InstanceService for InstanceListener {
+    async fn create(
+        &self,
+        request: Request<Instance>,
+    ) -> Result<Response<Self::CreateStream>, Status> {
+        debug!("{:?}", request);
+
+        let (tx, rx) = mpsc::channel(4);
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    type CreateStream = ReceiverStream<Result<InstanceStatus, Status>>;
+
+    async fn start(&self, request: Request<InstanceIdentifier>) -> Result<Response<()>, Status> {
+        debug!("{:?}", request);
+
+        Ok(Response::new(()))
+    }
+
+    async fn stop(&self, request: Request<InstanceIdentifier>) -> Result<Response<()>, Status> {
+        debug!("{:?}", request);
+
+        Ok(Response::new(()))
+    }
+
+    async fn destroy(&self, request: Request<InstanceIdentifier>) -> Result<Response<()>, Status> {
+        debug!("{:?}", request);
+
+        Ok(Response::new(()))
+    }
+}

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -1,1 +1,7 @@
 pub mod storage;
+pub mod manager;
+
+#[derive(Debug)]
+pub struct Node {
+    id: String
+}

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -1,9 +1,51 @@
+use proto::scheduler::{
+    Instance, InstanceStatus, NodeRegisterRequest, NodeRegisterResponse, NodeStatus,
+    NodeUnregisterRequest, NodeUnregisterResponse,
+};
+use tokio::sync::{mpsc, oneshot};
+use tonic::Response;
+
 pub mod instance_listener;
 pub mod manager;
 pub mod node_listener;
 pub mod storage;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Node {
     id: String,
+}
+
+pub type NodeIdentifier = String;
+
+#[derive(Debug)]
+pub enum Event {
+    // Instance events
+    InstanceCreate(
+        Instance,
+        mpsc::Sender<Result<InstanceStatus, tonic::Status>>,
+    ),
+    InstanceStart(
+        NodeIdentifier,
+        oneshot::Sender<Result<Response<()>, tonic::Status>>,
+    ),
+    InstanceStop(
+        NodeIdentifier,
+        oneshot::Sender<Result<Response<()>, tonic::Status>>,
+    ),
+    InstanceDestroy(
+        NodeIdentifier,
+        oneshot::Sender<Result<Response<()>, tonic::Status>>,
+    ),
+
+    // Node events
+    NodeRegister(
+        NodeRegisterRequest,
+        oneshot::Sender<Result<Response<NodeRegisterResponse>, tonic::Status>>,
+    ),
+    NodeUnregister(
+        NodeUnregisterRequest,
+        oneshot::Sender<Result<Response<NodeUnregisterResponse>, tonic::Status>>,
+    ),
+    NodeStatus(NodeStatus, mpsc::Sender<Result<(), tonic::Status>>),
 }

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -1,7 +1,9 @@
-pub mod storage;
+pub mod instance_listener;
 pub mod manager;
+pub mod node_listener;
+pub mod storage;
 
 #[derive(Debug)]
 pub struct Node {
-    id: String
+    id: String,
 }

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -1,3 +1,14 @@
+use log::{info, debug};
+use scheduler::manager::Manager;
+
 fn main() {
-    println!("Hello, world!");
+    env_logger::init();
+
+    info!("starting up");
+
+    let scheduler = Manager::new();
+    debug!("initialized manager struct with {:?}", scheduler);
+    scheduler.run();
+
+    info!("shutting down");
 }

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -9,13 +9,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let manager = Manager::new();
     debug!("initialized manager struct with data : {:?}", manager);
     
-    let handlers = manager.run()?;
-    info!("started");
-
-    // wait the end of all the threads
-    for handler in handlers {
-        handler.await?;
-    }
+    manager.run().await?;
 
     info!("shutting down");
     Ok(())

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -1,14 +1,22 @@
 use log::{info, debug};
 use scheduler::manager::Manager;
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
-
     info!("starting up");
 
-    let scheduler = Manager::new();
-    debug!("initialized manager struct with {:?}", scheduler);
-    scheduler.run();
+    let manager = Manager::new();
+    debug!("initialized manager struct with data : {:?}", manager);
+    
+    let handlers = manager.run()?;
+    info!("started");
+
+    // wait the end of all the threads
+    for handler in handlers {
+        handler.await?;
+    }
 
     info!("shutting down");
+    Ok(())
 }

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -3,7 +3,7 @@ use proto::scheduler::{node_service_server::NodeServiceServer, Instance};
 use tokio::task::JoinHandle;
 use tonic::transport::Server;
 
-use crate::{storage::Storage, Node};
+use crate::{storage::Storage, Node, node_listener::NodeListener};
 
 #[derive(Debug)]
 pub struct Manager {
@@ -52,11 +52,17 @@ impl Manager {
         info!("creating grpc server ...");
 
         let addr = "127.0.0.1:50051".parse().unwrap();
+        let node_listener = NodeListener::default();
+        debug!("create node listener with data : {:?}", node_listener);
 
         tokio::spawn(async move {
             info!("started grpc server at {}", addr);
-
-            Server::builder().serve(addr).await.unwrap();
+  
+            Server::builder()
+                .add_service(NodeServiceServer::new(node_listener))
+                .serve(addr)
+                .await
+                .unwrap();
         })
     }
 

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -83,13 +83,19 @@ impl Manager {
     /// Returns:
     ///
     /// A vector of JoinHandles.
-    pub fn run(&self) -> Result<Vec<JoinHandle<()>>, Box<dyn std::error::Error>> {
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut handlers = vec![];
 
         // create listeners and serve the grpc server
         handlers.push(self.create_grpc_server());
 
         info!("scheduler running and ready to receive incoming requests ...");
-        Ok(handlers)
+
+        // wait the end of all the threads
+        for handler in handlers {
+            handler.await?;
+        }
+
+        Ok(())
     }
 }

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -1,5 +1,6 @@
-use log::info;
 use proto::scheduler::Instance;
+use log::{info, debug};
+use tokio::task::JoinHandle;
 
 use crate::{storage::Storage, Node};
 
@@ -40,7 +41,14 @@ impl Manager {
         &self.nodes
     }
 
-    pub fn run(&self) {
+    /// This function runs the scheduler.
+    /// 
+    /// Returns:
+    /// 
+    /// A vector of JoinHandles.
+    pub fn run(&self) -> Result<Vec<JoinHandle<()>>, Box<dyn std::error::Error>> {
+        let mut handlers = vec![];
         info!("scheduler running and ready to receive incoming requests ...");
+        Ok(handlers)
     }
 }

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -1,19 +1,22 @@
+use std::sync::Arc;
+
 use log::{debug, info};
 use proto::scheduler::{
     instance_service_server::InstanceServiceServer, node_service_server::NodeServiceServer,
-    Instance,
+    Instance, InstanceStatus, NodeRegisterResponse, NodeUnregisterResponse,
 };
-use tokio::task::JoinHandle;
-use tonic::transport::Server;
+use tokio::sync::mpsc;
+use tokio::{sync::oneshot, task::JoinHandle};
+use tonic::{transport::Server, Response};
 
 use crate::{
-    instance_listener::InstanceListener, node_listener::NodeListener, storage::Storage, Node,
+    instance_listener::InstanceListener, node_listener::NodeListener, storage::Storage, Event, Node,
 };
 
 #[derive(Debug)]
 pub struct Manager {
-    instances: Storage<Instance>,
-    nodes: Storage<Node>,
+    instances: Arc<Storage<Instance>>,
+    nodes: Arc<Storage<Node>>,
 }
 
 impl Manager {
@@ -23,9 +26,12 @@ impl Manager {
     ///
     /// A new Manager struct
     pub fn new() -> Self {
+        let instances = Arc::new(Storage::new());
+        let nodes = Arc::new(Storage::new());
+
         Manager {
-            instances: Storage::new(),
-            nodes: Storage::new(),
+            instances: instances,
+            nodes: nodes,
         }
     }
 
@@ -34,33 +40,37 @@ impl Manager {
     /// Returns:
     ///
     /// A reference to the instances storage.
-    pub fn get_instances_storage(&self) -> &Storage<Instance> {
-        &self.instances
+    pub fn instances(&self) -> Arc<Storage<Instance>> {
+        self.instances.clone()
     }
 
-    ///This function returns a reference to the nodes storage.
+    /// This function returns a reference to the nodes storage.
     ///
     /// Returns:
     ///
     /// A reference to the nodes storage.
-    pub fn get_nodes_storage(&self) -> &Storage<Node> {
-        &self.nodes
+    pub fn nodes(&self) -> Arc<Storage<Node>> {
+        self.nodes.clone()
     }
 
-    /// This function creates a gRPC server that listens on port 50051 and registers the
-    /// `NodeServiceServer` with the server
+    /// It creates a gRPC server that listens on port 50051 and spawns a new thread to handle incoming
+    /// requests
+    ///
+    /// Arguments:
+    ///
+    /// * `tx`: mpsc::Sender<Event>
     ///
     /// Returns:
     ///
     /// A JoinHandle<()>
-    fn create_grpc_server(&self) -> JoinHandle<()> {
+    fn create_grpc_server(&self, tx: mpsc::Sender<Event>) -> JoinHandle<()> {
         info!("creating grpc server ...");
-
         let addr = "127.0.0.1:50051".parse().unwrap();
-        let node_listener = NodeListener::default();
+
+        let node_listener = NodeListener::new(tx.clone());
         debug!("create node listener with data : {:?}", node_listener);
 
-        let instance_listener = InstanceListener::default();
+        let instance_listener = InstanceListener::new(tx);
         debug!(
             "create instance listener with data : {:?}",
             instance_listener
@@ -78,16 +88,89 @@ impl Manager {
         })
     }
 
-    /// This function runs the scheduler.
+    /// Create a multi-producer, single-consumer channel with a buffer size of 32
+    pub fn create_mpsc_channel<T>() -> (mpsc::Sender<T>, mpsc::Receiver<T>) {
+        debug!("creating mpsc channel ...");
+        let (tx, rx): (mpsc::Sender<T>, mpsc::Receiver<T>) = mpsc::channel(32);
+        debug!("created mpsc channel");
+        (tx, rx)
+    }
+
+    /// It creates a channel that can be used to send a single message from one thread to another
+    pub fn create_oneshot_channel<T>() -> (oneshot::Sender<T>, oneshot::Receiver<T>) {
+        debug!("creating oneshot channel ...");
+        let (tx, rx): (oneshot::Sender<T>, oneshot::Receiver<T>) = oneshot::channel();
+        debug!("created oneshot channel");
+        (tx, rx)
+    }
+
+    /// This function listens for incoming events from the event bus and dispatches them to the
+    /// orchestrator
+    ///
+    /// Arguments:
+    ///
+    /// * `rx`: mpsc::Receiver<Event>
     ///
     /// Returns:
     ///
-    /// A vector of JoinHandles.
+    /// A JoinHandle<()>
+    fn listen_events(&self, mut rx: mpsc::Receiver<Event>) -> JoinHandle<()> {
+        info!("listening for incoming events ...");
+
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                debug!("received event : {:?}", event);
+                match event {
+                    Event::InstanceCreate(instance, tx) => {
+                        info!("received instance create event : {:?}", instance);
+                        tx.send(Ok(InstanceStatus::default())).await.unwrap();
+                    }
+                    Event::InstanceStart(id, tx) => {
+                        info!("received instance start event : {:?}", id);
+                        tx.send(Ok(Response::new(()))).unwrap();
+                    }
+                    Event::InstanceStop(id, tx) => {
+                        info!("received instance stop event : {:?}", id);
+                        tx.send(Ok(Response::new(()))).unwrap();
+                    }
+                    Event::InstanceDestroy(id, tx) => {
+                        info!("received instance destroy event : {:?}", id);
+                        tx.send(Ok(Response::new(()))).unwrap();
+                    }
+                    Event::NodeRegister(request, tx) => {
+                        info!("received node register event : {:?}", request);
+                        tx.send(Ok(Response::new(NodeRegisterResponse::default())))
+                            .unwrap();
+                    }
+                    Event::NodeUnregister(request, tx) => {
+                        info!("received node unregister event : {:?}", request);
+                        tx.send(Ok(Response::new(NodeUnregisterResponse::default())))
+                            .unwrap();
+                    }
+                    Event::NodeStatus(status, tx) => {
+                        info!("received node status event : {:?}", status);
+                        tx.send(Ok(())).await.unwrap();
+                    }
+                }
+            }
+        })
+    }
+
+    /// The function creates a channel to communicate with the orchestrator, creates a gRPC server and a
+    /// listener for incoming events, and then waits for the end of all the threads
+    ///
+    /// Returns:
+    ///
+    /// A Result<(), Box<dyn std::error::Error>>
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         let mut handlers = vec![];
+        let (tx, rx) = Self::create_mpsc_channel();
 
         // create listeners and serve the grpc server
-        handlers.push(self.create_grpc_server());
+        handlers.push(self.create_grpc_server(tx));
+
+        // listen for incoming events and pass them to the orchestrator
+        handlers.push(self.listen_events(rx));
 
         info!("scheduler running and ready to receive incoming requests ...");
 

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -1,0 +1,46 @@
+use log::info;
+use proto::scheduler::Instance;
+
+use crate::{storage::Storage, Node};
+
+#[derive(Debug)]
+pub struct Manager {
+    instances: Storage<Instance>,
+    nodes: Storage<Node>
+}
+
+impl Manager {
+    /// `new` creates a new `Manager` struct with two empty `Storage` structs
+    /// 
+    /// Returns:
+    /// 
+    /// A new Manager struct
+    pub fn new() -> Self {
+        Manager {
+            instances: Storage::new(),
+            nodes: Storage::new()
+        }
+    }
+    
+    /// This function returns a reference to the instances storage.
+    /// 
+    /// Returns:
+    /// 
+    /// A reference to the instances storage.
+    pub fn get_instances_storage(&self) -> &Storage<Instance> {
+        &self.instances
+    }
+
+    ///This function returns a reference to the nodes storage.
+    /// 
+    /// Returns:
+    /// 
+    /// A reference to the nodes storage.
+    pub fn get_nodes_storage(&self) -> &Storage<Node> {
+        &self.nodes
+    }
+
+    pub fn run(&self) {
+        info!("scheduler running and ready to receive incoming requests ...");
+    }
+}

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -1,53 +1,76 @@
-use proto::scheduler::Instance;
-use log::{info, debug};
+use log::{debug, info};
+use proto::scheduler::{node_service_server::NodeServiceServer, Instance};
 use tokio::task::JoinHandle;
+use tonic::transport::Server;
 
 use crate::{storage::Storage, Node};
 
 #[derive(Debug)]
 pub struct Manager {
     instances: Storage<Instance>,
-    nodes: Storage<Node>
+    nodes: Storage<Node>,
 }
 
 impl Manager {
     /// `new` creates a new `Manager` struct with two empty `Storage` structs
-    /// 
+    ///
     /// Returns:
-    /// 
+    ///
     /// A new Manager struct
     pub fn new() -> Self {
         Manager {
             instances: Storage::new(),
-            nodes: Storage::new()
+            nodes: Storage::new(),
         }
     }
-    
+
     /// This function returns a reference to the instances storage.
-    /// 
+    ///
     /// Returns:
-    /// 
+    ///
     /// A reference to the instances storage.
     pub fn get_instances_storage(&self) -> &Storage<Instance> {
         &self.instances
     }
 
     ///This function returns a reference to the nodes storage.
-    /// 
+    ///
     /// Returns:
-    /// 
+    ///
     /// A reference to the nodes storage.
     pub fn get_nodes_storage(&self) -> &Storage<Node> {
         &self.nodes
     }
 
-    /// This function runs the scheduler.
-    /// 
+    /// This function creates a gRPC server that listens on port 50051 and registers the
+    /// `NodeServiceServer` with the server
+    ///
     /// Returns:
-    /// 
+    ///
+    /// A JoinHandle<()>
+    fn create_grpc_server(&self) -> JoinHandle<()> {
+        info!("creating grpc server ...");
+
+        let addr = "127.0.0.1:50051".parse().unwrap();
+
+        tokio::spawn(async move {
+            info!("started grpc server at {}", addr);
+
+            Server::builder().serve(addr).await.unwrap();
+        })
+    }
+
+    /// This function runs the scheduler.
+    ///
+    /// Returns:
+    ///
     /// A vector of JoinHandles.
     pub fn run(&self) -> Result<Vec<JoinHandle<()>>, Box<dyn std::error::Error>> {
         let mut handlers = vec![];
+
+        // create listeners and serve the grpc server
+        handlers.push(self.create_grpc_server());
+
         info!("scheduler running and ready to receive incoming requests ...");
         Ok(handlers)
     }

--- a/scheduler/src/manager.rs
+++ b/scheduler/src/manager.rs
@@ -1,9 +1,14 @@
 use log::{debug, info};
-use proto::scheduler::{node_service_server::NodeServiceServer, Instance};
+use proto::scheduler::{
+    instance_service_server::InstanceServiceServer, node_service_server::NodeServiceServer,
+    Instance,
+};
 use tokio::task::JoinHandle;
 use tonic::transport::Server;
 
-use crate::{storage::Storage, Node, node_listener::NodeListener};
+use crate::{
+    instance_listener::InstanceListener, node_listener::NodeListener, storage::Storage, Node,
+};
 
 #[derive(Debug)]
 pub struct Manager {
@@ -55,11 +60,18 @@ impl Manager {
         let node_listener = NodeListener::default();
         debug!("create node listener with data : {:?}", node_listener);
 
+        let instance_listener = InstanceListener::default();
+        debug!(
+            "create instance listener with data : {:?}",
+            instance_listener
+        );
+
         tokio::spawn(async move {
             info!("started grpc server at {}", addr);
-  
+
             Server::builder()
                 .add_service(NodeServiceServer::new(node_listener))
+                .add_service(InstanceServiceServer::new(instance_listener))
                 .serve(addr)
                 .await
                 .unwrap();

--- a/scheduler/src/node_listener.rs
+++ b/scheduler/src/node_listener.rs
@@ -1,0 +1,33 @@
+use log::debug;
+use proto::scheduler::{node_service_server::NodeService, NodeRegisterRequest, NodeStatus, NodeUnregisterRequest, NodeUnregisterResponse, NodeRegisterResponse};
+use tonic::{Request, Status, Response, Streaming};
+
+#[derive(Default, Debug)]
+pub struct NodeListener {}
+
+#[tonic::async_trait]
+impl NodeService for NodeListener {
+    async fn status(
+        &self,
+        request: Request<Streaming<NodeStatus>>,
+    ) -> Result<Response<()>, Status> {
+        debug!("{:?}", request);
+        Ok(Response::new(()))
+    }
+
+    async fn register(
+        &self,
+        request: Request<NodeRegisterRequest>,
+    ) -> Result<Response<NodeRegisterResponse>, Status> {
+        debug!("{:?}", request);
+        Ok(Response::new(NodeRegisterResponse::default()))
+    }
+
+    async fn unregister(
+        &self,
+        request: Request<NodeUnregisterRequest>,
+    ) -> Result<Response<NodeUnregisterResponse>, Status> {
+        debug!("{:?}", request);
+        Ok(Response::new(NodeUnregisterResponse::default()))
+    }
+}

--- a/scheduler/src/storage.rs
+++ b/scheduler/src/storage.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 /// Defining a trait called IStorage that takes a generic type T.
-trait IStorage<T> {
+pub trait IStorage<T> {
     fn get(&self, id: &str) -> Option<&T>;
     fn get_mut(&mut self, id: &str) -> Option<&mut T>;
     fn update(&mut self, id: &str, value: T);


### PR DESCRIPTION
This PR adds the basic application for the scheduler.

Explanations:

The main function creates an instance of the `Manager` structure.
Who is responsible for managing startup, data, and channels between all threads.

Currently, the manager only creates the gRPC server and initializes the storage.

gRPC services return a default response for all functions.