### PR TITLE
feat(kudoctl): return error on error status code

### DIFF
--- a/kudoctl/src/request.rs
+++ b/kudoctl/src/request.rs
@@ -1,8 +1,31 @@
 use crate::config::Config;
 use reqwest::header;
+use reqwest::Body;
 use reqwest::Response;
 use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde::Serialize;
 use std::error::Error;
+
+// Represent the error returned by the controller when a request fails
+#[derive(Deserialize)]
+struct ErrorResponse {
+    pub error: String,
+}
+
+// Error returned by this module when an endpoint returns an error.
+#[derive(Debug)]
+pub struct RequestError {
+    pub error: String,
+    pub status: u16,
+}
+impl std::error::Error for RequestError {}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RequestError ({}): {}", self.status, self.error)
+    }
+}
 
 // Wrapper around reqwest to make requests to the controller.
 pub struct Client {
@@ -34,17 +57,17 @@ impl Client {
     }
 
     // Send a request to the controller.
-    async fn send_request(
+    async fn send_request<U: Serialize>(
         &self,
         endpoint: &str,
         method: reqwest::Method,
-        body: Option<&str>,
+        body: Option<&U>,
     ) -> Result<Response, Box<dyn Error>> {
         let url = self.base_url.join(endpoint)?;
         let mut request = (*self).client.request(method, url);
 
         if let Some(body) = body {
-            request = request.body(body.to_owned());
+            request = request.json(body);
         }
 
         request
@@ -54,13 +77,29 @@ impl Client {
     }
 
     // Send a request to the controller and deserialize the response.
-    pub async fn send_json_request<T: DeserializeOwned>(
+    //
+    // returns a `RequestError` if a non-2xx response is received.
+    pub async fn send_json_request<T: DeserializeOwned, U: Serialize>(
         &self,
         endpoint: &str,
         method: reqwest::Method,
-        body: Option<&str>,
+        body: Option<&U>,
     ) -> Result<T, Box<dyn Error>> {
         let response = self.send_request(endpoint, method, body).await?;
+
+        // Check if the response is an error.
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+
+            // Read the error message from the response body.
+
+            let error_response: ErrorResponse = response.json().await?;
+            return Err(Box::new(RequestError {
+                error: error_response.error,
+                status,
+            }));
+        }
+
         response
             .json::<T>()
             .await


### PR DESCRIPTION
send_json_request now throws an error when a non-2xx status code is received, the error struct contains the message in the body and the status code.