### PR TITLE
fix: wrong property name for env variables in workload definition

### DIFF
--- a/kudoctl/src/resource/parse.rs
+++ b/kudoctl/src/resource/parse.rs
@@ -79,9 +79,9 @@ env:
 
         match resource {
             Resource::Workload(workload) => {
-                assert_eq!(workload.enviroment.as_ref().unwrap().len(), 2);
-                assert_eq!(workload.enviroment.as_ref().unwrap()[0], "KEY1=VALUE1");
-                assert_eq!(workload.enviroment.as_ref().unwrap()[1], "KEY2=VALUE2");
+                assert_eq!(workload.env.as_ref().unwrap().len(), 2);
+                assert_eq!(workload.env.as_ref().unwrap()[0], "KEY1=VALUE1");
+                assert_eq!(workload.env.as_ref().unwrap()[1], "KEY2=VALUE2");
             }
             _ => panic!("Unexpected resource type"),
         }

--- a/kudoctl/src/resource/workload.rs
+++ b/kudoctl/src/resource/workload.rs
@@ -8,7 +8,8 @@ pub struct Workload {
     pub uri: String,
     pub resources: Resources,
     pub ports: Option<Vec<String>>,
-    pub enviroment: Option<Vec<String>>,
+    /// environment variables to set on the workload
+    pub env: Option<Vec<String>>,
 }
 
 // Resources assigned to a workload 


### PR DESCRIPTION
The definition in `workload.rs` had the property containing the environment variables named "environment" whereas everywhere else it was named "env".

This PR fixes it and the failed test reported by #33 