### PR TITLE
feat(kudoctl): add get resources command

### DIFF
--- a/kudoctl/src/client/workload.rs
+++ b/kudoctl/src/client/workload.rs
@@ -1,8 +1,12 @@
 use anyhow::{Context, Result};
 use log::debug;
 use reqwest::Method;
+use serde::{Deserialize, Serialize};
 
-use crate::{client::types::IdResponse, resource::workload};
+use crate::{
+    client::types::IdResponse,
+    resource::{self, workload},
+};
 
 use super::request::Client;
 
@@ -16,4 +20,28 @@ pub async fn create(client: &Client, workload: &workload::Workload) -> Result<St
         .context("Error creating workload")?;
     debug!("Workload {} created", response.id);
     Ok(response.id)
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetWorkloadResponse {
+    pub count: u64,
+    pub workloads: Vec<resource::Resource>,
+    #[serde(skip)]
+    pub show_header: bool,
+}
+
+/// Get the workloads in the cluster.
+///
+/// Returns a vector of workloads.
+pub async fn list(client: &Client) -> Result<GetWorkloadResponse> {
+    let response: GetWorkloadResponse = (*client)
+        .send_json_request::<GetWorkloadResponse, ()>("/workload", Method::GET, None)
+        .await
+        .context("Error getting workloads")?;
+    debug!(
+        "{} total workloads, {} workloads received ",
+        response.count,
+        response.workloads.len()
+    );
+    Ok(response)
 }

--- a/kudoctl/src/subcommands/apply.rs
+++ b/kudoctl/src/subcommands/apply.rs
@@ -20,7 +20,7 @@ pub struct Apply {
     no_update: bool,
 }
 
-pub async fn execute(args: Apply, conf: &config::Config) -> Result<()> {
+pub async fn execute(args: Apply, conf: &config::Config) -> Result<String> {
     let client = Client::new(conf).context("Error creating client")?;
 
     // read the yaml file if -f is used
@@ -67,5 +67,5 @@ pub async fn execute(args: Apply, conf: &config::Config) -> Result<()> {
             );
         }
     }
-    Ok(())
+    Ok("".to_string())
 }

--- a/kudoctl/src/subcommands/get/mod.rs
+++ b/kudoctl/src/subcommands/get/mod.rs
@@ -1,0 +1,54 @@
+mod output;
+mod resources;
+
+use self::output::OutputFormat;
+use crate::config;
+use anyhow::{bail, Result};
+use clap::{Args, ValueEnum};
+
+#[derive(Debug, Args)]
+pub struct GetSubcommand {
+    /// Change the output format
+    #[clap(short = 'F', long, arg_enum, value_parser)]
+    format: Option<OutputFormat>,
+
+    /// Don’t show header (human readable only)
+    #[clap(long)]
+    no_header: bool,
+
+    /// Define the type of element(s) to get
+    ///
+    /// Add an id after the type to get the element.
+    /// Use plural to get all the elements of the type,
+    /// use singular to get only one element of the type (ID parameter is required).
+    #[clap(arg_enum, value_parser)]
+    subject: GetSubjects,
+
+    /// Search for a specific element
+    #[clap(value_name = "ID")]
+    id: Option<String>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum GetSubjects {
+    /// resources
+    Resources,
+    Resource,
+
+    /// instances
+    Instances,
+    Instance,
+}
+
+/// match the subcommand to get the correct info
+pub async fn execute(args: GetSubcommand, conf: &config::Config) -> Result<String> {
+    let format = args.format.unwrap_or(OutputFormat::HumanReadable);
+    let show_header = !args.no_header;
+
+    match args.subject {
+        GetSubjects::Resources => resources::execute(conf, format, show_header).await,
+        GetSubjects::Resource | GetSubjects::Instances | GetSubjects::Instance => {
+            bail!(format!("{:?} not implemented yet", args.subject))
+        }
+    }
+}

--- a/kudoctl/src/subcommands/get/output.rs
+++ b/kudoctl/src/subcommands/get/output.rs
@@ -1,0 +1,25 @@
+use std::fmt::Display;
+
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use serde::Serialize;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum OutputFormat {
+    /// Human readable format
+    HumanReadable,
+    /// JSON format
+    Json,
+    /// YAML format
+    Yaml,
+}
+
+/// Formats the output of a `get` command.
+pub fn format_output<T: Serialize + Display>(output: T, format: OutputFormat) -> Result<String> {
+    match format {
+        OutputFormat::HumanReadable => Ok(format!("{}", output)),
+        OutputFormat::Json => serde_json::to_string(&output).map_err(anyhow::Error::from),
+        OutputFormat::Yaml => serde_yaml::to_string(&output).map_err(anyhow::Error::from),
+    }
+    .context("Error formatting output")
+}

--- a/kudoctl/src/subcommands/get/resources.rs
+++ b/kudoctl/src/subcommands/get/resources.rs
@@ -1,0 +1,41 @@
+use crate::{
+    client::{self, request::Client, workload::GetWorkloadResponse},
+    config, resource,
+};
+use anyhow::{Context, Result};
+use clap::Args;
+use std::fmt::Display;
+
+use super::output::{self, OutputFormat}; // import without risk of name clashing
+
+#[derive(Debug, Args)]
+pub struct GetResources {}
+
+/// get resources subcommand execution
+pub async fn execute(
+    conf: &config::Config,
+    format: OutputFormat,
+    show_header: bool,
+) -> Result<String> {
+    let client = Client::new(conf).context("Error creating client")?;
+    let mut result = client::workload::list(&client).await?;
+    result.show_header = show_header;
+    output::format_output(result, format)
+}
+
+impl Display for GetWorkloadResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.show_header {
+            writeln!(f, "NAME\tTYPE")?;
+        }
+
+        for r in &self.workloads {
+            match r {
+                resource::Resource::Workload(workload) => {
+                    writeln!(f, "{}\tWorkload\n", workload.name)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/kudoctl/src/subcommands/mod.rs
+++ b/kudoctl/src/subcommands/mod.rs
@@ -1,22 +1,35 @@
-use clap::Subcommand;
-use log::info;
-
 use crate::config;
-
+use clap::Subcommand;
+use log::error;
 mod apply;
+mod get;
 
 #[derive(Subcommand)]
 pub enum Subcommands {
     Apply(apply::Apply),
+    Get(get::GetSubcommand),
 }
 
+/// Match the subcommand to execute
+///
+/// # Organisation
+/// Every subcommand has its own module,
+/// with a struct to configure the arguments and an execute function.
 pub async fn match_subcommand(command: Subcommands, conf: &config::Config) {
     let result = match command {
-        Subcommands::Apply(args) => apply::execute(args, conf),
-    }
-    .await;
+        Subcommands::Apply(args) => apply::execute(args, conf).await,
+        Subcommands::Get(args) => get::execute(args, conf).await,
+    };
 
-    if result.is_err() {
-        info!("{}", result.unwrap_err());
+    // Print the result or the error
+    match result {
+        Ok(result) => {
+            if !result.is_empty() {
+                println!("{}", result);
+            }
+        }
+        Err(err) => {
+            error!("{}", err);
+        }
     }
 }


### PR DESCRIPTION
This PR adds the `get resources` command.

I’m not sure where to put the implementation of the custom trait `HumanReadable` for `GetWorkloadResponse`. By default I put it in the subcommand execution folder. 