### PR TITLE
feat(kudoctl): get instances command

### DIFF
--- a/kudoctl/src/client/instance.rs
+++ b/kudoctl/src/client/instance.rs
@@ -1,8 +1,9 @@
 use anyhow::Context;
 use log::debug;
 use reqwest::Method;
+use serde::{Deserialize, Serialize};
 
-use crate::client::types::IdResponse;
+use crate::{client::types::IdResponse, resource::workload};
 
 use super::request::Client;
 
@@ -20,4 +21,40 @@ pub async fn create(client: &Client, workload_id: &String) -> anyhow::Result<Str
         .context("Error creating instance")?;
     debug!("Instance {} created", response.id);
     Ok(response.id)
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Instance {
+    pub id: String,
+    pub name: String,
+    pub r#type: String,
+    pub uri: String,
+    pub ports: Vec<String>,
+    pub env: Vec<String>,
+    pub resources: workload::Resources,
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetInstancesResponse {
+    pub count: u64,
+    pub instances: Vec<Instance>,
+
+    /// used for formatting in the Display impl
+    #[serde(skip)]
+    pub show_header: bool,
+}
+
+/// List the instances in the cluster.
+pub async fn list(client: &Client) -> anyhow::Result<GetInstancesResponse> {
+    let response: GetInstancesResponse = (*client)
+        .send_json_request::<GetInstancesResponse, ()>("/instance", Method::GET, None)
+        .await
+        .context("Error getting instances")?;
+    debug!(
+        "{} total instances, {} instances received ",
+        response.count,
+        response.instances.len()
+    );
+    Ok(response)
 }

--- a/kudoctl/src/subcommands/get/instances.rs
+++ b/kudoctl/src/subcommands/get/instances.rs
@@ -1,0 +1,33 @@
+use super::output::{self, OutputFormat};
+use crate::{
+    client::{self, instance::GetInstancesResponse, request::Client},
+    config,
+};
+use anyhow::{Context, Result};
+use std::fmt::Display;
+
+/// get instances subcommand execution
+/// Does the request, then formats the output.
+pub async fn execute(
+    conf: &config::Config,
+    format: OutputFormat,
+    show_header: bool,
+) -> Result<String> {
+    let client = Client::new(conf).context("Error creating client")?;
+    let mut result = client::instance::list(&client).await?;
+    result.show_header = show_header;
+    output::format_output(result, format)
+}
+
+impl Display for GetInstancesResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.show_header {
+            writeln!(f, "ID\tSTATUS")?;
+        }
+
+        for inst in &self.instances {
+            writeln!(f, "{}\t{}\n", inst.id, inst.status)?;
+        }
+        Ok(())
+    }
+}

--- a/kudoctl/src/subcommands/get/mod.rs
+++ b/kudoctl/src/subcommands/get/mod.rs
@@ -1,6 +1,6 @@
+mod instances;
 mod output;
 mod resources;
-
 use self::output::OutputFormat;
 use crate::config;
 use anyhow::{bail, Result};
@@ -47,7 +47,8 @@ pub async fn execute(args: GetSubcommand, conf: &config::Config) -> Result<Strin
 
     match args.subject {
         GetSubjects::Resources => resources::execute(conf, format, show_header).await,
-        GetSubjects::Resource | GetSubjects::Instances | GetSubjects::Instance => {
+        GetSubjects::Instances => instances::execute(conf, format, show_header).await,
+        GetSubjects::Resource | GetSubjects::Instance => {
             bail!(format!("{:?} not implemented yet", args.subject))
         }
     }

--- a/kudoctl/src/subcommands/get/resources.rs
+++ b/kudoctl/src/subcommands/get/resources.rs
@@ -3,13 +3,9 @@ use crate::{
     config, resource,
 };
 use anyhow::{Context, Result};
-use clap::Args;
 use std::fmt::Display;
 
 use super::output::{self, OutputFormat}; // import without risk of name clashing
-
-#[derive(Debug, Args)]
-pub struct GetResources {}
 
 /// get resources subcommand execution
 pub async fn execute(


### PR DESCRIPTION
Implements the `kudoctl get instances command` that lists all the running instances on the cluster.