### PR TITLE
feat(scheduler): add configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ proto/Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
-
 # Config files
 **/controller.conf
+**/scheduler.conf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,9 +1630,14 @@ dependencies = [
 name = "scheduler"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "confy",
  "env_logger 0.8.4",
  "log",
  "proto",
+ "serde",
+ "serde_derive",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -12,3 +12,8 @@ env_logger = "0.8.4"
 tonic = "0.7.2"
 tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
 tokio-stream = { version = "0.1", features = ["net"] }
+serde = "1.0.142"
+serde_derive = "1.0.142"
+confy = "0.4.0"
+anyhow = "1.0.62"
+thiserror = "1.0.32"

--- a/scheduler/src/config.rs
+++ b/scheduler/src/config.rs
@@ -1,0 +1,22 @@
+use serde_derive::{Deserialize, Serialize};
+
+/// `Config` is a struct that contains the configuration of the scheduler.
+///
+/// Properties:
+///
+/// * `host`: The hostname or IP address of the gRPC server.
+/// * `port`: The port that the gRPC server will listen on.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            host: "127.0.0.1".to_string(),
+            port: 50052,
+        }
+    }
+}

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -2,13 +2,29 @@ use proto::scheduler::{
     Instance, InstanceStatus, NodeRegisterRequest, NodeRegisterResponse, NodeStatus,
     NodeUnregisterRequest, NodeUnregisterResponse,
 };
+use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tonic::Response;
 
+pub mod config;
 pub mod instance_listener;
 pub mod manager;
 pub mod node_listener;
 pub mod storage;
+
+#[derive(Error, Debug)]
+pub enum SchedulerError {
+    #[error("unable to read the configuration file's path")]
+    ConfigPathReadError(#[from] std::io::Error),
+    #[error("unable to read the configuration file")]
+    ConfigReadError(#[from] confy::ConfyError),
+    #[error("invalid grpc address in configuration file")]
+    InvalidGrpcAddress,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+    #[error("unknown scheduler error")]
+    Unknown,
+}
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -1,12 +1,23 @@
+use std::env;
+
 use log::{debug, info};
-use scheduler::manager::Manager;
+use scheduler::{config::Config, manager::Manager, SchedulerError};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     info!("starting up");
 
-    let manager = Manager::new();
+    info!("loading config");
+    let mut dir = env::current_dir().map_err(SchedulerError::ConfigPathReadError)?; // get executable path
+    dir.push("scheduler.conf"); // add config file name
+
+    // load config from path
+    let config: Config =
+        confy::load_path(dir.as_path()).map_err(SchedulerError::ConfigReadError)?;
+    debug!("config: {:?}", config);
+
+    let manager = Manager::new(config);
     debug!("initialized manager struct with data : {:?}", manager);
 
     manager.run().await?;


### PR DESCRIPTION
This MR adds the configuration file for the scheduler.

The configuration file is created in the same folder where the binary is run and the file name is `scheduler.conf` in TOML format.