### PR TITLE
feat: "make all" command to run every check locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,7 @@ lint:
 .PHONY: format
 format:
 	cargo fmt -- --check --config format_code_in_doc_comments=true
+
+.PHONY: all
+all: kudo check lint format
+	@echo "Everything ok"


### PR DESCRIPTION
This is a simple make rule to execute everything without writing a long command (`make lint && make format && make check && make kudo`).

The new command to run every check would be `make all`.