### PR TITLE
fix: multiple gRPC interfaces conflicting

### DIFF
--- a/controller/lib/src/internal_api/interface.rs
+++ b/controller/lib/src/internal_api/interface.rs
@@ -8,21 +8,17 @@ use tonic::transport::Server;
 pub struct InternalAPIInterface {}
 
 impl InternalAPIInterface {
-    pub async fn new(address: SocketAddr, num_workers: usize) -> Self {
-        info!(
-            "Starting {} gRPC worker(s) listening on {}",
-            num_workers, address
-        );
+    pub async fn new(address: SocketAddr) -> Self {
+        info!("Starting gRPC server listening on {}", address);
 
-        for _ in 1..num_workers {
-            tokio::spawn(async move {
-                Server::builder()
-                    .add_service(NodeServiceServer::new(NodeController::default()))
-                    .serve(address)
-                    .await
-                    .unwrap();
-            });
-        }
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(NodeServiceServer::new(NodeController::default()))
+                .serve(address)
+                .await
+                .unwrap();
+        });
+
         Self {}
     }
 }

--- a/controller/src/config.rs
+++ b/controller/src/config.rs
@@ -10,7 +10,6 @@ pub struct KudoControllerConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InternalAPIConfig {
     pub grpc_server_addr: SocketAddr,
-    pub grpc_server_num_workers: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -27,7 +26,6 @@ impl Default for KudoControllerConfig {
                     std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     50051,
                 ),
-                grpc_server_num_workers: 1,
             },
             external_api: ExternalAPIConfig {
                 http_server_addr: SocketAddr::new(

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -13,11 +13,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let config: config::KudoControllerConfig = confy::load_path("controller.conf")?;
 
     // gRPC Server
-    internal_api::interface::InternalAPIInterface::new(
-        config.internal_api.grpc_server_addr,
-        config.internal_api.grpc_server_num_workers,
-    )
-    .await;
+    internal_api::interface::InternalAPIInterface::new(config.internal_api.grpc_server_addr).await;
 
     // HTTP Server
     external_api::interface::ExternalAPIInterface::new(


### PR DESCRIPTION
Removed the worker feature because it generates conflict errors when creating gRPC server (address already in use error)

The for loop was generating n-1 workers instead of n workers