### PR TITLE
fix: change resourceSummary types in all proto files and clean up node manager crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "memoffset",
+ "once_cell",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1163,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1234,23 @@ name = "node-agent"
 version = "0.1.0"
 dependencies = [
  "proto",
+]
+
+[[package]]
+name = "node_manager"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "sysinfo",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1519,6 +1590,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1891,21 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "sysinfo"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "controller",
     "node-agent",
+    "node-agent/node_manager",
     "network",
     "kudoctl",
     "scheduler",

--- a/node-agent/node_manager/src/lib.rs
+++ b/node-agent/node_manager/src/lib.rs
@@ -10,6 +10,12 @@ pub struct NodeSystem {
     sys: System,
 }
 
+impl Default for NodeSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NodeSystem {
     // used in all functions to access system
     pub fn new() -> Self {
@@ -101,7 +107,7 @@ impl NodeSystem {
             }
         }
 
-        main_disk_total_space = main_disk_total_space / BIT_TO_GB;
+        main_disk_total_space /= BIT_TO_GB;
 
         debug!("total disk space: {} GB", main_disk_total_space);
 

--- a/node-agent/node_manager/src/lib.rs
+++ b/node-agent/node_manager/src/lib.rs
@@ -13,7 +13,7 @@ pub struct NodeSystem {
 impl NodeSystem {
     // used in all functions to access system
     pub fn new() -> Self {
-        let mut sys = System::new_all();
+        let sys = System::new_all();
 
         NodeSystem { sys }
     }
@@ -148,37 +148,37 @@ mod tests {
 
     #[test]
     fn test_total_cpu() {
-        let mut sys = init_system();
+        let mut node_system = init_system();
 
-        assert!(sys.total_cpu() >= 1000) // minimum 1 core
+        assert!(node_system.total_cpu() >= 1000) // minimum 1 core
     }
 
     #[test]
     fn test_used_cpu() {
-        let mut sys = init_system();
+        let mut node_system = init_system();
 
-        let total_cpu = sys.total_cpu();
-        let used_cpu = sys.used_cpu();
+        let total_cpu = node_system.total_cpu();
+        let used_cpu = node_system.used_cpu();
 
         assert!(used_cpu <= total_cpu)
     }
 
     #[test]
     fn test_used_memory() {
-        let mut sys = init_system();
+        let mut node_system = init_system();
 
-        let total_memory = sys.total_memory();
-        let used_memory = sys.used_memory();
+        let total_memory = node_system.total_memory();
+        let used_memory = node_system.used_memory();
 
         assert!(used_memory <= total_memory)
     }
 
     #[test]
     fn test_used_disk() {
-        let mut sys = init_system();
+        let mut node_system = init_system();
 
-        let total_disk = sys.total_disk();
-        let used_disk = sys.used_disk();
+        let total_disk = node_system.total_disk();
+        let used_disk = node_system.used_disk();
 
         assert!(used_disk <= total_disk)
     }

--- a/proto/src/agent.proto
+++ b/proto/src/agent.proto
@@ -55,9 +55,9 @@ message Port {
 
 // Represent the resource usage of a node or a workload 
 message ResourceSummary {
-  int32 cpu = 1;
-  int32 memory = 2;
-  int32 disk = 3;
+  uint64 cpu = 1;
+  uint64 memory = 2;
+  uint64 disk = 3;
 }
 
 message Resource {

--- a/proto/src/controller.proto
+++ b/proto/src/controller.proto
@@ -57,9 +57,9 @@ message Port {
 
 // Represent a resource entry
 message ResourceSummary {
-  int32 cpu = 1;
-  int32 memory = 2;
-  int32 disk = 3;
+  uint64 cpu = 1;
+  uint64 memory = 2;
+  uint64 disk = 3;
 }
 
 // Represents the resources used by the Instance & the limit where the workload

--- a/proto/src/scheduler.proto
+++ b/proto/src/scheduler.proto
@@ -37,9 +37,9 @@ message Port {
 }
 
 message ResourceSummary {
-    int32 cpu = 1;
-    int32 memory = 2;
-    int32 disk = 3;
+    uint64 cpu = 1;
+    uint64 memory = 2;
+    uint64 disk = 3;
 }
 
 message Resource {


### PR DESCRIPTION
I need to change all functions type to i32 to match proto files definition.

This will fix errors when trying to send node resources to the scheduler in node-agent main.rs. 