### PR TITLE
feat(kudoctl): CLI quality of life improvements

### DIFF
--- a/kudoctl/src/config.rs
+++ b/kudoctl/src/config.rs
@@ -30,6 +30,7 @@ pub fn get_verbosity_level_from_string(verbosity_level_str: &str) -> LevelFilter
         "warn" => LevelFilter::Warn,
         "info" => LevelFilter::Info,
         "debug" => LevelFilter::Debug,
+        "trace" => LevelFilter::Trace,
         _ => LevelFilter::Info,
     }
 }

--- a/kudoctl/src/logger.rs
+++ b/kudoctl/src/logger.rs
@@ -1,0 +1,33 @@
+use chrono::Utc;
+use log::{LevelFilter, SetLoggerError};
+use std::io::Write;
+
+/// Configure the logger with the given verbosity level.
+pub fn setup_env_logger(verbosity_level: LevelFilter) -> Result<(), SetLoggerError> {
+    env_logger::builder()
+        .format(move |buf, record| {
+            let utc = Utc::now();
+
+            match verbosity_level {
+                // Write the file path and more time details if we are in trace mode
+                LevelFilter::Trace => writeln!(
+                    buf,
+                    "{} - {}:{} [{}] {}",
+                    utc,
+                    record.file().unwrap_or(""),
+                    record.line().unwrap_or(0),
+                    record.level(),
+                    record.args()
+                ),
+                _ => writeln!(
+                    buf,
+                    "{} [{:5}] {}",
+                    utc.format("%F %T"),
+                    record.level(),
+                    record.args()
+                ),
+            }
+        })
+        .filter_level(verbosity_level)
+        .try_init()
+}

--- a/kudoctl/src/main.rs
+++ b/kudoctl/src/main.rs
@@ -1,20 +1,19 @@
 mod config;
-use chrono::Utc;
 use clap::Parser;
 mod client;
-use log::LevelFilter;
+use logger::setup_env_logger;
+mod logger;
 mod resource;
-use std::io::Write;
 mod subcommands;
 
 /// Official CLI implementation for the kudo project
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    /// Set verbosity level, can be 'debug', 'info', 'warn' or 'error'
+    /// Set verbosity level, can be 'trace', 'debug', 'info', 'warn' or 'error'
     ///
     /// Default: 'info', if the flag is set but no level is given, 'debug' is used.
-    #[clap(short, long)]
+    /// Logs are written to stderr, the only stdout output is the data returned by the command.
     #[clap(short, long, global = true)]
     verbosity: Option<Option<String>>,
 
@@ -36,41 +35,22 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse the CLI arguments
+
     let cli = Cli::parse();
 
+    // parse config
+
     let mut global_config = config::read_config()?;
+
+    // set verbosity level
 
     if let Some(verbosity) = cli.verbosity {
         global_config.verbosity_level =
             config::get_verbosity_level_from_string(verbosity.as_deref().unwrap_or("debug"));
     }
 
-    env_logger::builder()
-        .format(move |buf, record| {
-            let utc = Utc::now();
-
-            match global_config.verbosity_level {
-                // Write the file path and more time details if we are in trace mode
-                LevelFilter::Trace => writeln!(
-                    buf,
-                    "{} - {}:{} [{}] {}",
-                    utc,
-                    record.file().unwrap_or(""),
-                    record.line().unwrap_or(0),
-                    record.level(),
-                    record.args()
-                ),
-                _ => writeln!(
-                    buf,
-                    "{} [{:5}] {}",
-                    utc.format("%F %T"),
-                    record.level(),
-                    record.args()
-                ),
-            }
-        })
-        .filter_level(global_config.verbosity_level)
-        .try_init()?;
+    setup_env_logger(global_config.verbosity_level)?;
 
     if let Some(host) = cli.host.as_deref() {
         global_config.controller_url = host.to_string();

--- a/kudoctl/src/main.rs
+++ b/kudoctl/src/main.rs
@@ -15,12 +15,13 @@ struct Cli {
     ///
     /// Default: 'info', if the flag is set but no level is given, 'debug' is used.
     #[clap(short, long)]
+    #[clap(short, long, global = true)]
     verbosity: Option<Option<String>>,
 
     /// Set the controller adress
     ///
     /// This has priority over the config file and enviorment variable.
-    #[clap(short, long)]
+    #[clap(short, long, global = true)]
     host: Option<String>,
 
     /// Define which namespace to target

--- a/kudoctl/src/subcommands/mod.rs
+++ b/kudoctl/src/subcommands/mod.rs
@@ -30,9 +30,11 @@ pub async fn match_subcommand(command: Subcommands, conf: &config::Config) {
             if !result.is_empty() {
                 println!("{}", result);
             }
+            std::process::exit(0);
         }
         Err(err) => {
             error!("{}", err);
+            std::process::exit(1);
         }
     }
 }


### PR DESCRIPTION
- Set exit code to 1 on error.
- Mark verbosity and host as global parameters.
- Move logger setup to a separate function.