### PR TITLE
fix : Etcd get_all always return None

### DIFF
--- a/controller/lib/src/etcd/mod.rs
+++ b/controller/lib/src/etcd/mod.rs
@@ -52,9 +52,8 @@ impl EtcdClient {
                     values.push(value.to_string());
                 }
             }
-            Some(values)
-        });
-        None
+            values
+        })
     }
 }
 /*


### PR DESCRIPTION
None has been removed.