### PR TITLE
Draft: feat(controller): implement instance logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "etcd-client",
  "log",
  "proto",
+ "rand",
  "serde",
  "serde_json",
  "tokio",
@@ -1733,6 +1734,7 @@ name = "proto"
 version = "0.1.0"
 dependencies = [
  "prost",
+ "serde",
  "tonic",
  "tonic-build",
 ]

--- a/controller/lib/Cargo.toml
+++ b/controller/lib/Cargo.toml
@@ -13,5 +13,5 @@ tonic = "0.7.2"
 proto = { path = "../../proto" }
 log = "0.4.0"
 tokio = { version = "1.20.0", features = ["rt-multi-thread", "macros"] }
+rand = "0.8.5"
 serde_json = "1.0"
-

--- a/controller/lib/src/external_api/instance/controller.rs
+++ b/controller/lib/src/external_api/instance/controller.rs
@@ -1,0 +1,172 @@
+use std::sync::Arc;
+
+use crate::external_api::interface::ActixAppState;
+
+use super::super::workload::service::WorkloadService;
+use super::model::{InstanceDTO, Pagination};
+use super::service;
+use actix_web::http::StatusCode;
+use actix_web::{web, HttpResponse, Responder, Scope};
+use tokio::sync::Mutex;
+pub struct InstanceController {}
+
+impl InstanceController {
+    pub fn services(&self) -> Scope {
+        web::scope("/instance")
+            .service(
+                web::resource("/{namespace}")
+                    .route(web::get().to(InstanceController::get_instances))
+                    .route(web::post().to(InstanceController::post_instance)),
+            )
+            .service(
+                web::resource("/{namespace}/{name}")
+                    .route(web::delete().to(InstanceController::delete_instance))
+                    .route(web::get().to(InstanceController::get_instance)),
+            )
+    }
+
+    /// `post_instance` is an async function that handle **/instance/\<namespace>** route (POST)
+    /// # Description:
+    /// * Create and start an instance
+    /// # Arguments:
+    ///
+    /// * `namespace`: web::Path<String> - This is the namespace that the instance will be created in.
+    /// * `body`: web::Json<InstanceDTO> - Contains the workload_name to create the instance from it.
+
+    pub async fn post_instance(
+        namespace: web::Path<String>,
+        body: web::Json<InstanceDTO>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let instance_service =
+            service::InstanceService::new(&data.grpc_address, &data.etcd_address)
+                .await
+                .map_err(|err| {
+                    HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(format!("Error creating instance service, {:?}", err))
+                })
+                .unwrap();
+        let mut workload_service = WorkloadService::new(&data.etcd_address).await.unwrap();
+        match workload_service
+            .get_workload(&body.workload_name, &namespace)
+            .await
+        {
+            Ok(workload) => {
+                match super::service::InstanceService::retrieve_and_start_instance_from_workload(
+                    Arc::new(Mutex::new(instance_service)),
+                    &workload.id,
+                )
+                .await
+                {
+                    Ok(_) => HttpResponse::build(StatusCode::CREATED)
+                        .body("Instance creating and starting..."),
+                    Err(_) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body("Internal Server Error"),
+                }
+            }
+            Err(_) => HttpResponse::build(StatusCode::NOT_FOUND).body("Workload not found"),
+        }
+    }
+    /// It deletes a instance from etcd and grpc.
+    ///
+    /// # Arguments:
+    ///
+    /// * `id`: The id of the instance to delete
+    /// * `namespace`: The namespace of the workload
+    ///
+    /// # Returns:
+    ///
+    /// A Result<(), InstanceError>
+    pub async fn delete_instance(
+        params: web::Path<(String, String)>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut instance_service =
+            service::InstanceService::new(&data.grpc_address, &data.etcd_address)
+                .await
+                .unwrap();
+        let (namespace, name) = params.into_inner();
+        match instance_service
+            .get_instance(format!("{}.{}", namespace, name).as_str())
+            .await
+        {
+            Ok(instance) => match instance_service.delete_instance(instance).await {
+                Ok(_) => HttpResponse::build(StatusCode::OK).body("Instance deleted"),
+                Err(err) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Internal Server Error, {}", err)),
+            },
+            Err(_) => HttpResponse::build(StatusCode::NOT_FOUND).body("Instance not found"),
+        }
+    }
+
+    /// It gets a instance from etcd, and if it exists, check if the namespace is the same.
+    ///
+    /// # Arguments:
+    ///
+    /// * `namespace`: The namespace of the instance
+    /// * `name`: The workload name to get
+    ///
+    /// # Returns:
+    ///
+    /// A Result<String, InstanceError>
+    pub async fn get_instance(
+        params: web::Path<(String, String)>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut instance_service =
+            service::InstanceService::new(&data.grpc_address, &data.etcd_address)
+                .await
+                .map_err(|err| {
+                    HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(format!("Error creating instance service, {:?}", err))
+                })
+                .unwrap();
+        let (namespace, name) = params.into_inner();
+        match instance_service
+            .get_instance(format!("{}.{}", namespace, name).as_str())
+            .await
+        {
+            Ok(instance) => match serde_json::to_string(&instance) {
+                Ok(instance_str) => HttpResponse::build(StatusCode::OK).body(instance_str),
+                Err(err) => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Internal Server Error {}", err)),
+            },
+            Err(err) => HttpResponse::build(StatusCode::NOT_FOUND).body(err.to_string()),
+        }
+    }
+
+    /// `get_instances` is an async function that handle **/instance/\<namespace>** route (GET)
+    /// # Description:
+    /// * Get all instances in the namespace
+    /// # Arguments:
+    ///
+    /// * `namespace`: The namespace of the instance you want to retrieve.
+    /// * `pagination`: Option<web::Query<Pagination>>
+    pub async fn get_instances(
+        namespace: web::Path<String>,
+        pagination: Option<web::Query<Pagination>>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut instance_service =
+            service::InstanceService::new(&data.grpc_address, &data.etcd_address)
+                .await
+                .map_err(|err| {
+                    HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                        .body(format!("Error creating instance service, {:?}", err))
+                })
+                .unwrap();
+
+        match pagination {
+            Some(pagination) => {
+                let instances = instance_service
+                    .get_instances(pagination.limit, pagination.offset, &namespace)
+                    .await;
+                web::Json(instances)
+            }
+            None => {
+                let instances = instance_service.get_instances(0, 0, &namespace).await;
+                web::Json(instances)
+            }
+        }
+    }
+}

--- a/controller/lib/src/external_api/instance/filter.rs
+++ b/controller/lib/src/external_api/instance/filter.rs
@@ -1,0 +1,54 @@
+use super::model::{Instance, InstanceError};
+
+/// `FilterService` is a struct that can be used as a service in the WorkloadService.
+pub struct FilterService {}
+
+impl FilterService {
+    pub fn new() -> Self {
+        FilterService {}
+    }
+
+    /// It takes a vector of workloads and a limit, and returns a vector of workloads that is limited to the
+    /// number of workloads specified by the limit
+    ///
+    /// # Arguments:
+    ///
+    /// * `workloads`: A vector of workloads to be limited.
+    /// * `limit`: The number of workloads to return.
+    ///
+    /// # Returns:
+    ///
+    /// A vector of workloads.
+
+    pub fn limit(&mut self, instances: &Vec<Instance>, mut limit: u32) -> Vec<Instance> {
+        if limit > instances.len() as u32 {
+            limit = instances.len() as u32;
+        }
+        instances[0..limit as usize].to_vec()
+    }
+
+    /// "Return a subset of the workloads vector, starting at the offset index."
+    ///
+    /// The first thing we do is check if the offset is greater than the length of the workloads vector. If
+    /// it is, we return an error
+    ///
+    /// # Arguments:
+    ///
+    /// * `workloads`: A vector of workloads to be filtered.
+    /// * `offset`: The offset to start from.
+    ///
+    /// # Returns:
+    ///
+    /// A vector of workloads
+
+    pub fn offset(
+        &mut self,
+        instances: &Vec<Instance>,
+        offset: u32,
+    ) -> Result<Vec<Instance>, InstanceError> {
+        if offset > instances.len() as u32 {
+            return Err(InstanceError::OutOfRange);
+        }
+        Ok(instances[offset as usize..].to_vec())
+    }
+}

--- a/controller/lib/src/external_api/instance/mod.rs
+++ b/controller/lib/src/external_api/instance/mod.rs
@@ -1,0 +1,4 @@
+pub mod controller;
+mod filter;
+mod model;
+mod service;

--- a/controller/lib/src/external_api/instance/model.rs
+++ b/controller/lib/src/external_api/instance/model.rs
@@ -1,0 +1,173 @@
+use std::net::Ipv4Addr;
+
+use proto::controller::{InstanceState, Type};
+use rand::{distributions::Alphanumeric, Rng};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub enum InstanceError {
+    InstanceNotFound,
+    OutOfRange,
+    Etcd(String),
+    Grpc(String),
+    SerdeError(serde_json::Error),
+    GenerateIp(String),
+}
+
+impl std::fmt::Display for InstanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            InstanceError::InstanceNotFound => write!(f, "Instance not found"),
+            InstanceError::OutOfRange => write!(f, "Instance out of range"),
+            InstanceError::Etcd(err) => write!(f, "Etcd error: {}", err),
+            InstanceError::Grpc(err) => write!(f, "Grpc error: {}", err),
+            InstanceError::SerdeError(err) => write!(f, "Serde error: {}", err),
+            InstanceError::GenerateIp(err) => write!(f, "Generate ip error: {}", err),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Instance {
+    pub id: String,
+    pub name: String,
+    pub r#type: Type,
+    pub state: InstanceState,
+    pub status_description: String,
+    pub num_restarts: i32,
+    pub uri: String,
+    pub environment: Vec<String>,
+    pub resource: Option<Resource>,
+    pub ports: Vec<Port>,
+    pub ip: Ipv4Addr,
+    pub namespace: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Resource {
+    pub limit: Option<ResourceSummary>,
+    pub usage: Option<ResourceSummary>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct InstanceDTO {
+    pub workload_name: String,
+}
+
+#[derive(Deserialize, Serialize)]
+
+pub struct Pagination {
+    pub limit: u32,
+    pub offset: u32,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct ResourceSummary {
+    pub cpu: u64,
+    pub memory: u64,
+    pub disk: u64,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Port {
+    pub source: i32,
+    pub dest: i32,
+}
+
+impl Instance {
+    pub fn update_instance(&mut self, instance_status: proto::scheduler::InstanceStatus) {
+        self.state =
+            InstanceState::from_i32(instance_status.status).unwrap_or(InstanceState::Scheduling);
+        self.status_description = instance_status.status_description;
+        self.resource = instance_status.resource.map(|resource| Resource {
+            limit: resource.limit.map(|resource_summary| ResourceSummary {
+                cpu: resource_summary.cpu,
+                memory: resource_summary.memory,
+                disk: resource_summary.disk,
+            }),
+            usage: resource.usage.map(|resource_summary| ResourceSummary {
+                cpu: resource_summary.cpu,
+                memory: resource_summary.memory,
+                disk: resource_summary.disk,
+            }),
+        });
+    }
+}
+
+// Because we don't want to add a From<> to the ::InstanceState enum
+#[allow(clippy::from_over_into)]
+impl Into<proto::scheduler::Instance> for Instance {
+    fn into(self) -> proto::scheduler::Instance {
+        proto::scheduler::Instance {
+            id: self.id,
+            name: self.name,
+            r#type: self.r#type as i32,
+            status: self.state as i32,
+            environnement: self.environment,
+            ip: self.ip.to_string(),
+            ports: self
+                .ports
+                .into_iter()
+                .map(|port| proto::scheduler::Port {
+                    source: port.source,
+                    destination: port.dest,
+                })
+                .collect(),
+            resource: self.resource.map(|resource| proto::scheduler::Resource {
+                limit: resource
+                    .limit
+                    .map(|resource_summary| proto::scheduler::ResourceSummary {
+                        cpu: resource_summary.cpu,
+                        memory: resource_summary.memory,
+                        disk: resource_summary.disk,
+                    }),
+                usage: resource
+                    .usage
+                    .map(|resource_summary| proto::scheduler::ResourceSummary {
+                        cpu: resource_summary.cpu,
+                        memory: resource_summary.memory,
+                        disk: resource_summary.disk,
+                    }),
+            }),
+            uri: self.uri,
+        }
+    }
+}
+
+impl From<super::super::workload::model::Workload> for Instance {
+    fn from(workload: super::super::workload::model::Workload) -> Self {
+        let random_id: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(5)
+            .map(char::from)
+            .collect();
+        Self {
+            id: format!("{}-{}", workload.id, random_id),
+            name: format!("{}-{}", workload.name, random_id),
+            r#type: Type::Container,
+            state: InstanceState::Scheduling,
+            status_description: "".to_string(),
+            num_restarts: 0,
+            uri: workload.uri,
+            environment: workload.environment,
+            namespace: workload.namespace,
+            resource: Some(Resource {
+                limit: Some(ResourceSummary {
+                    cpu: workload.resources.cpu,
+                    memory: workload.resources.memory,
+                    disk: workload.resources.disk,
+                }),
+                usage: None,
+            }),
+            ports: workload
+                .ports
+                .into_iter()
+                .map(|port| Port {
+                    source: port.source,
+                    dest: port.destination,
+                })
+                .collect(),
+            ip: Ipv4Addr::new(10, 0, 0, 1),
+        }
+    }
+}

--- a/controller/lib/src/external_api/instance/service.rs
+++ b/controller/lib/src/external_api/instance/service.rs
@@ -1,0 +1,295 @@
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use super::filter::FilterService;
+use super::model::{Instance, InstanceError};
+use crate::etcd::EtcdClient;
+use crate::external_api::workload::model::Workload;
+use crate::grpc_client::interface::SchedulerClientInterface;
+use proto::controller::InstanceState;
+use serde_json;
+use tokio::sync::Mutex;
+use tonic::Request;
+
+pub struct InstanceService {
+    grpc_service: SchedulerClientInterface,
+    etcd_service: EtcdClient,
+    filter_service: FilterService,
+}
+
+// `InstanceService` is a struct that is inspired from Controllers Provider Modules architectures. It is used as a service in the InstanceController. A service can use other services.
+/// Properties:
+///
+/// * `grpc_service`: This is the service that will be used to filter to interact with grpc.
+/// * `etcd_service`: This is the service that will be used to interact with etcd.
+/// * `filter_service`: This is the service that will be used to filter the instances.
+
+impl InstanceService {
+    pub async fn new(grpc_address: &str, etcd_address: &SocketAddr) -> Result<Self, InstanceError> {
+        Ok(InstanceService {
+            grpc_service: SchedulerClientInterface::new(grpc_address.to_string())
+                .await
+                .map_err(|err| InstanceError::Grpc(err.to_string()))?,
+            etcd_service: EtcdClient::new(etcd_address.to_string())
+                .await
+                .map_err(|err| InstanceError::Etcd(err.to_string()))?,
+            filter_service: FilterService::new(),
+        })
+    }
+
+    /// `generate_ip` is an async function that generate an ip address for a instance.
+    /// # Description:
+    /// It stores the last ip used in ETCD and increment it by 1 every time it is used .
+    /// * Get all workload in the namespace
+    /// # Return
+    /// An Result<Ipv4Addr, InstanceError>
+    pub async fn generate_ip(&mut self) -> Result<Ipv4Addr, InstanceError> {
+        let mut ip = Ipv4Addr::new(10, 0, 0, 1);
+        match self.etcd_service.get("last_ip").await {
+            Some(value) => {
+                let ip_address: Ipv4Addr = serde_json::from_str(&value)
+                    .map_err(InstanceError::SerdeError)
+                    .unwrap();
+                let mut octets = ip_address.octets();
+                for i in 0..3 {
+                    if octets[3 - i] < 255 {
+                        octets[3 - i] += 1;
+                        break;
+                    } else {
+                        octets[3 - i] = 0;
+                    }
+                }
+                ip = Ipv4Addr::from(octets);
+                self.etcd_service
+                    .put(
+                        "last_ip",
+                        &serde_json::to_string(&ip)
+                            .map_err(InstanceError::SerdeError)
+                            .unwrap(),
+                    )
+                    .await
+                    .map_err(|err| InstanceError::Etcd(err.to_string()))?;
+                Ok(ip)
+            }
+            None => {
+                self.etcd_service
+                    .put(
+                        "last_ip",
+                        &serde_json::to_string(&ip)
+                            .map_err(InstanceError::SerdeError)
+                            .unwrap(),
+                    )
+                    .await
+                    .map_err(|err| InstanceError::Etcd(err.to_string()))?;
+                Ok(ip)
+            }
+        }
+    }
+
+    /// It creates a new instance in etcd and call the `schedule` function of the grpc service
+    ///
+    /// # Arguments:
+    ///
+    /// * `this`: the method is called on the `this` object. Used to handle threads.
+    /// * `workload_id`: The id of the workload that the instance will be created for.
+    ///
+    /// # Returns:
+    ///
+    /// A Result.
+    pub async fn retrieve_and_start_instance_from_workload(
+        this: Arc<Mutex<Self>>,
+        workload_id: &str,
+    ) -> Result<(), InstanceError> {
+        let ip = this
+            .clone()
+            .lock()
+            .await
+            .generate_ip()
+            .await
+            .map_err(|err| InstanceError::GenerateIp(err.to_string()))
+            .unwrap();
+        match this
+            .clone()
+            .lock()
+            .await
+            .etcd_service
+            .get(workload_id)
+            .await
+        {
+            Some(workload) => {
+                let workload_parsed: Workload = serde_json::from_str(&workload).unwrap();
+                let mut instance = Instance::from(workload_parsed);
+                instance.ip = ip;
+                log::info!("Instance retrieved from workload: {:?}", instance);
+                Self::schedule_instance(this, instance);
+
+                Ok(())
+            }
+            None => Err(InstanceError::InstanceNotFound),
+        }
+    }
+
+    /// Schedule an new instance by calling the GRPC client and recursively call this function if the instance is not scheduled.
+    ///
+    /// # Arguments:
+    ///
+    /// * `this`: the method is called on the `this` object. Used to handle threads.
+    /// * `instance`: The instance to schedule
+    fn schedule_instance(this: Arc<Mutex<Self>>, mut instance: Instance) {
+        //Spawn a thread to start the instance
+        tokio::spawn(async move {
+            loop {
+                let mut stream = this
+                    .clone()
+                    .lock()
+                    .await
+                    .grpc_service
+                    .create_instance(Request::new(Instance::into(instance.clone())))
+                    .await
+                    .map_err(|err| InstanceError::Grpc(err.to_string()))
+                    .unwrap()
+                    .into_inner();
+
+                let mut last_state = InstanceState::Scheduling;
+
+                while let Some(instance_status) = stream
+                    .message()
+                    .await
+                    .map_err(|err| InstanceError::Grpc(err.to_string()))
+                    .unwrap()
+                {
+                    instance.update_instance(instance_status.clone());
+
+                    this.clone()
+                        .lock()
+                        .await
+                        .etcd_service
+                        .put(
+                            &instance.id,
+                            &serde_json::to_string(&instance)
+                                .map_err(InstanceError::SerdeError)
+                                .unwrap(),
+                        )
+                        .await
+                        .map_err(|err| InstanceError::Etcd(err.to_string()))
+                        .unwrap();
+
+                    last_state = InstanceState::from_i32(instance_status.status)
+                        .unwrap_or(InstanceState::Scheduling);
+                }
+
+                if last_state == InstanceState::Terminated {
+                    break;
+                }
+
+                instance.num_restarts += 1;
+
+                this.clone()
+                    .lock()
+                    .await
+                    .etcd_service
+                    .put(
+                        &instance.id,
+                        &serde_json::to_string(&instance)
+                            .map_err(InstanceError::SerdeError)
+                            .unwrap(),
+                    )
+                    .await
+                    .map_err(|err| InstanceError::Grpc(err.to_string()))
+                    .unwrap();
+            }
+        });
+    }
+
+    /// Delete an instance from etcd and call the `destroy_instance` function of the grpc service
+    ///
+    /// # Arguments:
+    ///
+    /// * `instance`: The instance to delete
+    ///
+    /// # Returns:
+    ///
+    /// A Result.
+    pub async fn delete_instance(&mut self, instance: Instance) -> Result<(), InstanceError> {
+        match self.etcd_service.delete(instance.id.as_str()).await {
+            Some(_) => {
+                match self
+                    .grpc_service
+                    .destroy_instance(Request::new(proto::scheduler::InstanceIdentifier {
+                        id: instance.id,
+                    }))
+                    .await
+                {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err(InstanceError::Grpc("Error stopping instance".to_string())),
+                }
+            }
+            None => Err(InstanceError::InstanceNotFound),
+        }
+    }
+
+    /// Get an instance by it's name
+    ///
+    /// # Arguments:
+    ///
+    /// * `namespace`: The namespace of the instance
+    ///
+    /// # Returns:
+    ///
+    /// A Instance.
+    pub async fn get_instance(&mut self, instance_name: &str) -> Result<Instance, InstanceError> {
+        match self
+            .etcd_service
+            .get(format!("instance.{}", instance_name).as_str())
+            .await
+        {
+            Some(instance_str) => match serde_json::from_str::<Instance>(&instance_str) {
+                Ok(instance) => Ok(instance),
+                Err(_) => Err(InstanceError::InstanceNotFound),
+            },
+            None => Err(InstanceError::InstanceNotFound),
+        }
+    }
+
+    /// This function gets all instances from etcd, filters them by namespace and slice the result by limit and offset
+    /// If there is an error , the function always return an empty vector
+    /// # Arguments:
+    ///
+    /// * `limit`: The number of instances to return.
+    /// * `offset`: The offset of the instances to be returned.
+    /// * `namespace`: The namespace to filter by.
+    ///
+    /// # Returns:
+    ///
+    /// A vector of instances
+    pub async fn get_instances(
+        &mut self,
+        limit: u32,
+        offset: u32,
+        namespace: &str,
+    ) -> Vec<Instance> {
+        let mut vec: Vec<Instance> = Vec::new();
+        match self.etcd_service.get_all().await {
+            Some(instances) => {
+                for instance in instances {
+                    if let Ok(instance) = serde_json::from_str::<Instance>(&instance) {
+                        if instance.namespace == namespace {
+                            vec.push(instance);
+                        }
+                    }
+                }
+                if offset > 0 {
+                    match self.filter_service.offset(&vec, limit) {
+                        Ok(instances) => vec = instances,
+                        Err(_) => return vec![],
+                    }
+                }
+                if limit > 0 {
+                    vec = self.filter_service.limit(&vec, limit);
+                }
+            }
+            None => return vec![],
+        }
+        vec
+    }
+}

--- a/controller/lib/src/external_api/interface.rs
+++ b/controller/lib/src/external_api/interface.rs
@@ -1,5 +1,5 @@
 use super::namespace;
-use super::workload;
+use super::{instance, workload};
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpResponse, HttpServer};
 use log::info;
@@ -9,10 +9,16 @@ pub struct ExternalAPIInterface {}
 
 pub struct ActixAppState {
     pub etcd_address: SocketAddr,
+    pub grpc_address: String,
 }
 
 impl ExternalAPIInterface {
-    pub async fn new(address: SocketAddr, num_workers: usize, etcd_address: SocketAddr) -> Self {
+    pub async fn new(
+        address: SocketAddr,
+        num_workers: usize,
+        etcd_address: SocketAddr,
+        grpc_address: String,
+    ) -> Self {
         info!(
             "Starting {} HTTP worker(s) listening on {}",
             num_workers, address
@@ -20,10 +26,14 @@ impl ExternalAPIInterface {
 
         HttpServer::new(move || {
             App::new()
-                .app_data(web::Data::new(ActixAppState { etcd_address }))
+                .app_data(web::Data::new(ActixAppState {
+                    etcd_address,
+                    grpc_address: grpc_address.clone(),
+                }))
                 .route("/health", web::get().to(HttpResponse::Ok))
                 .service(workload::controller::WorkloadController {}.services())
                 .service(namespace::controller::NamespaceController {}.services())
+                .service(instance::controller::InstanceController {}.services())
                 .wrap(Logger::default())
         })
         .workers(num_workers)

--- a/controller/lib/src/external_api/mod.rs
+++ b/controller/lib/src/external_api/mod.rs
@@ -1,4 +1,5 @@
 pub mod generic;
+mod instance;
 pub mod interface;
 mod namespace;
 mod workload;

--- a/controller/lib/src/external_api/workload/model.rs
+++ b/controller/lib/src/external_api/workload/model.rs
@@ -1,6 +1,7 @@
 use actix_web::HttpResponse;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug)]
 pub enum WorkloadError {
     WorkloadNotFound,
     Etcd(String),

--- a/controller/lib/src/grpc_client/interface.rs
+++ b/controller/lib/src/grpc_client/interface.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use log::{error, info};
 use proto::scheduler::instance_service_client::InstanceServiceClient;
 use proto::scheduler::{Instance, InstanceIdentifier, InstanceStatus};
@@ -8,6 +10,19 @@ use tonic::{Request, Response, Status, Streaming};
 pub enum SchedulerClientInterfaceError {
     ConnectionError(Error),
     RequestFailed(Status),
+}
+
+impl Display for SchedulerClientInterfaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchedulerClientInterfaceError::ConnectionError(error) => {
+                write!(f, "Connection error: {}", error)
+            }
+            SchedulerClientInterfaceError::RequestFailed(status) => {
+                write!(f, "Request failed: {}", status)
+            }
+        }
+    }
 }
 
 pub struct SchedulerClientInterface {

--- a/controller/src/config.rs
+++ b/controller/src/config.rs
@@ -10,6 +10,7 @@ pub struct KudoControllerConfig {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct InternalAPIConfig {
     pub grpc_server_addr: SocketAddr,
+    pub grpc_client_addr: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -27,6 +28,7 @@ impl Default for KudoControllerConfig {
                     std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     50051,
                 ),
+                grpc_client_addr: "http://127.0.0.1:50052".to_string(),
             },
             external_api: ExternalAPIConfig {
                 http_server_addr: SocketAddr::new(

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         config.external_api.http_server_addr,
         config.external_api.http_server_num_workers,
         config.external_api.etcd_address,
+        config.internal_api.grpc_client_addr,
     )
     .await;
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 prost = "0.10.4"
 tonic = "0.7.2"
+serde = { version = "1.0.139", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,12 +1,21 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure().compile(
-        &[
-            "./src/controller.proto",
-            "./src/agent.proto",
-            "./src/scheduler.proto",
-            "./src/network.proto",
-        ],
-        &["./src/"],
-    )?;
+    tonic_build::configure()
+        .type_attribute(
+            "controller.InstanceState",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "controller.Type",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .compile(
+            &[
+                "./src/controller.proto",
+                "./src/agent.proto",
+                "./src/scheduler.proto",
+                "./src/network.proto",
+            ],
+            &["./src/"],
+        )?;
     Ok(())
 }


### PR DESCRIPTION
# Overral explanation of our work :

Implement routes for `Instance`:

- [x] GET /instance/<namespace>/<instance_id> : Return one instance by id
- [x] DELETE /instance/<namespace>/<instance_id> : Delete one instance by id
- [x] GET /instance/<namespace> : Return all instances with filter
- [x] POST /instance/<namespace> : Instanciate an instance from a workload_id 

## Architecture

The code is divided into three parts :

- **Service** : It implements all the logic to interact with etcd ( get , put ...) and grpc (create_instance)
- **Controller** : Contains the route and functions they call
- **Model** : It implements all models used by the two other parts


## Tests

See this issue for the implementation of the tests

## Used libraries
    serde_json : serialise and deserialise Instance to JSON
    grpc : send request to the scheduler
   
