### PR TITLE
Feat : Create namespace logic 

### DIFF
--- a/controller/lib/Cargo.toml
+++ b/controller/lib/Cargo.toml
@@ -13,6 +13,5 @@ tonic = "0.7.2"
 proto = { path = "../../proto" }
 log = "0.4.0"
 tokio = { version = "1.20.0", features = ["rt-multi-thread", "macros"] }
-
 serde_json = "1.0"
 

--- a/controller/lib/src/external_api/interface.rs
+++ b/controller/lib/src/external_api/interface.rs
@@ -1,3 +1,4 @@
+use super::namespace;
 use super::workload;
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpResponse, HttpServer};
@@ -22,6 +23,7 @@ impl ExternalAPIInterface {
                 .app_data(web::Data::new(ActixAppState { etcd_address }))
                 .route("/health", web::get().to(HttpResponse::Ok))
                 .service(workload::controller::WorkloadController {}.services())
+                .service(namespace::controller::NamespaceController {}.services())
                 .wrap(Logger::default())
         })
         .workers(num_workers)

--- a/controller/lib/src/external_api/mod.rs
+++ b/controller/lib/src/external_api/mod.rs
@@ -1,3 +1,4 @@
 pub mod generic;
 pub mod interface;
+mod namespace;
 mod workload;

--- a/controller/lib/src/external_api/namespace/controller.rs
+++ b/controller/lib/src/external_api/namespace/controller.rs
@@ -1,0 +1,113 @@
+use crate::external_api::generic::model::Pagination;
+use crate::external_api::interface::ActixAppState;
+
+use super::model::NamespaceDTO;
+use super::service::NamespaceService;
+use actix_web::http::StatusCode;
+use actix_web::{web, HttpResponse, Responder, Scope};
+pub struct NamespaceController {}
+impl NamespaceController {
+    pub fn services(&self) -> Scope {
+        web::scope("/namespace")
+            .service(
+                web::resource("/{namespace_name}")
+                    .route(web::delete().to(NamespaceController::delete_namespace))
+                    .route(web::get().to(NamespaceController::namespace))
+                    .route(web::patch().to(NamespaceController::patch_namespace)),
+            )
+            .service(
+                web::resource("")
+                    .route(web::put().to(NamespaceController::put_namespace))
+                    .route(web::get().to(NamespaceController::get_all_namespace)),
+            )
+    }
+
+    pub async fn namespace(
+        params: web::Path<String>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut namespace_service = match NamespaceService::new(&data.etcd_address).await {
+            Ok(namespace) => namespace,
+            Err(e) => return e.to_http(),
+        };
+
+        let namespace_name = params.into_inner();
+
+        namespace_service
+            .namespace(&namespace_name)
+            .await
+            .map_or_else(|e| e.to_http(), |w| w.to_http())
+    }
+
+    pub async fn put_namespace(
+        body: web::Json<NamespaceDTO>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut namespace_service = match NamespaceService::new(&data.etcd_address).await {
+            Ok(namespace) => namespace,
+            Err(e) => return e.to_http(),
+        };
+        let namespace_dto = body.into_inner();
+        namespace_service
+            .create_namespace(namespace_dto)
+            .await
+            .map_or_else(|e| e.to_http(), |w| w.to_http())
+    }
+
+    pub async fn get_all_namespace(
+        pagination: Option<web::Query<Pagination>>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut namespace_service = match NamespaceService::new(&data.etcd_address).await {
+            Ok(namespace) => namespace,
+            Err(e) => return e.to_http(),
+        };
+
+        match pagination {
+            Some(pagination) => {
+                let namespaces = namespace_service
+                    .get_all_namespace(pagination.limit, pagination.offset)
+                    .await;
+                namespaces.to_http()
+            }
+            None => {
+                let namespaces = namespace_service.get_all_namespace(0, 0).await;
+                namespaces.to_http()
+            }
+        }
+    }
+
+    pub async fn patch_namespace(
+        params: web::Path<String>,
+        body: web::Json<NamespaceDTO>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut namespace_service = match NamespaceService::new(&data.etcd_address).await {
+            Ok(namespace) => namespace,
+            Err(e) => return e.to_http(),
+        };
+
+        let namespace_name = params.into_inner();
+        let namespace_dto = body.into_inner();
+
+        namespace_service
+            .update_namespace(namespace_dto, &namespace_name)
+            .await
+            .map_or_else(|e| e.to_http(), |w| w.to_http())
+    }
+
+    pub async fn delete_namespace(
+        params: web::Path<String>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut namespace_service = match NamespaceService::new(&data.etcd_address).await {
+            Ok(namespace) => namespace,
+            Err(e) => return e.to_http(),
+        };
+
+        let namespace_name = params.into_inner();
+
+        namespace_service.delete_namespace(&namespace_name).await;
+        HttpResponse::build(StatusCode::NO_CONTENT).body("Remove successfully")
+    }
+}

--- a/controller/lib/src/external_api/namespace/mod.rs
+++ b/controller/lib/src/external_api/namespace/mod.rs
@@ -1,0 +1,3 @@
+pub mod controller;
+pub mod model;
+pub mod service;

--- a/controller/lib/src/external_api/namespace/model.rs
+++ b/controller/lib/src/external_api/namespace/model.rs
@@ -1,0 +1,72 @@
+use actix_web::HttpResponse;
+use serde::{Deserialize, Serialize};
+
+pub enum NamespaceError {
+    NotFound,
+    Etcd(String),
+    NameAlreadyExists(String),
+    JsonToNamespace(String),
+    NamespaceToJson(String),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Metadata {}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Namespace {
+    pub id: String,
+    pub name: String,
+    pub metadata: Metadata,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NamespaceDTO {
+    pub name: String,
+}
+
+impl NamespaceError {
+    pub fn to_http(&self) -> HttpResponse {
+        match self {
+            NamespaceError::NotFound => HttpResponse::NotFound().body("Namespace not found"),
+            NamespaceError::Etcd(err) => {
+                HttpResponse::InternalServerError().body(format!("Etcd error: {} ", err))
+            }
+            NamespaceError::NameAlreadyExists(name) => HttpResponse::Conflict()
+                .body(format!("Namespace with name {} already exists", name)),
+            NamespaceError::JsonToNamespace(err) => HttpResponse::InternalServerError().body(
+                format!("Error while converting JSON string to Namespace : {}", err),
+            ),
+            NamespaceError::NamespaceToJson(err) => HttpResponse::InternalServerError().body(
+                format!("Error while converting the Namespace to JSON: {}", err),
+            ),
+        }
+    }
+}
+impl Namespace {
+    pub fn to_http(&self) -> HttpResponse {
+        match serde_json::to_string(&self) {
+            Ok(json) => HttpResponse::Ok().body(json),
+            Err(err) => HttpResponse::InternalServerError().body(format!(
+                "Error while converting the Namespace to JSON: {}",
+                err
+            )),
+        }
+    }
+}
+#[derive(Deserialize, Serialize)]
+pub struct NamespaceVector {
+    pub namespaces: Vec<Namespace>,
+}
+impl NamespaceVector {
+    pub fn new(namespaces: Vec<Namespace>) -> NamespaceVector {
+        NamespaceVector { namespaces }
+    }
+    pub fn to_http(&self) -> HttpResponse {
+        match serde_json::to_string(&self.namespaces) {
+            Ok(json) => HttpResponse::Ok().body(json),
+            Err(err) => HttpResponse::InternalServerError().body(format!(
+                "Error while converting the Namespace to JSON: {}",
+                err
+            )),
+        }
+    }
+}

--- a/controller/lib/src/external_api/namespace/service.rs
+++ b/controller/lib/src/external_api/namespace/service.rs
@@ -1,0 +1,117 @@
+use crate::etcd::EtcdClient;
+use crate::external_api::generic::filter::FilterService;
+use serde_json;
+use std::net::SocketAddr;
+
+use super::model::{Metadata, Namespace, NamespaceDTO, NamespaceError, NamespaceVector};
+
+pub struct NamespaceService {
+    etcd_service: EtcdClient,
+    filter_service: FilterService,
+}
+
+impl NamespaceService {
+    pub async fn new(etcd_address: &SocketAddr) -> Result<NamespaceService, NamespaceError> {
+        let inner = NamespaceService {
+            etcd_service: EtcdClient::new(etcd_address.to_string())
+                .await
+                .map_err(|err| NamespaceError::Etcd(err.to_string()))?,
+            filter_service: FilterService::new(),
+        };
+        Ok(inner)
+    }
+
+    pub async fn namespace(&mut self, namespace_name: &str) -> Result<Namespace, NamespaceError> {
+        let id = self.id(namespace_name);
+        match self.etcd_service.get(&id).await {
+            Some(namespace) => {
+                let namespace: Namespace = serde_json::from_str(&namespace)
+                    .map_err(|err| NamespaceError::JsonToNamespace(err.to_string()))?;
+                Ok(namespace)
+            }
+            None => Err(NamespaceError::NotFound),
+        }
+    }
+
+    pub async fn get_all_namespace(&mut self, limit: u32, offset: u32) -> NamespaceVector {
+        let mut new_vec: Vec<Namespace> = Vec::new();
+        match self.etcd_service.get_all().await {
+            Some(namespaces) => {
+                for namespace in namespaces {
+                    // if namespace deserialize failed , we don't want to throw error , so we just don't add it to the vector
+                    if let Ok(namespace) = serde_json::from_str::<Namespace>(&namespace) {
+                        new_vec.push(namespace);
+                    }
+                }
+                if offset > 0 {
+                    match self.filter_service.offset(&new_vec, offset) {
+                        Ok(namespaces) => new_vec = namespaces,
+                        Err(_) => return NamespaceVector::new(vec![]),
+                    }
+                }
+                if limit > 0 {
+                    new_vec = self.filter_service.limit(&new_vec, limit);
+                }
+                NamespaceVector::new(new_vec)
+            }
+            None => NamespaceVector::new(vec![]),
+        }
+    }
+
+    pub async fn create_namespace(
+        &mut self,
+        namespace_dto: NamespaceDTO,
+    ) -> Result<Namespace, NamespaceError> {
+        let id = self.id(&namespace_dto.name);
+        match self.namespace(&namespace_dto.name).await {
+            Ok(namespace) => Err(NamespaceError::NameAlreadyExists(namespace.name)),
+            Err(err) => match err {
+                NamespaceError::NotFound => {
+                    let namespace = Namespace {
+                        id: id.to_string(),
+                        name: namespace_dto.name,
+                        metadata: Metadata {},
+                    };
+                    let json = serde_json::to_string(&namespace)
+                        .map_err(|err| NamespaceError::NamespaceToJson(err.to_string()))?;
+                    self.etcd_service
+                        .put(&id, &json)
+                        .await
+                        .map_err(|err| NamespaceError::Etcd(err.to_string()))?;
+                    Ok(namespace)
+                }
+                _ => Err(err),
+            },
+        }
+    }
+
+    pub async fn update_namespace(
+        &mut self,
+        namespace_dto: NamespaceDTO,
+        namespace_name: &str,
+    ) -> Result<Namespace, NamespaceError> {
+        // we get the id before update , and the new id after update
+        let new_id = self.id(&namespace_dto.name);
+        self.namespace(namespace_name).await?;
+        let namespace = Namespace {
+            id: new_id.to_string(),
+            name: namespace_dto.name,
+            metadata: Metadata {},
+        };
+        let json = serde_json::to_string(&namespace)
+            .map_err(|err| NamespaceError::NamespaceToJson(err.to_string()))?;
+        self.etcd_service
+            .put(&new_id, &json)
+            .await
+            .map_err(|err| NamespaceError::Etcd(err.to_string()))?;
+        Ok(namespace)
+    }
+
+    pub async fn delete_namespace(&mut self, namespace_name: &str) {
+        let id = self.id(namespace_name);
+        _ = self.etcd_service.delete(&id).await;
+    }
+    pub fn id(&mut self, namespace_name: &str) -> String {
+        format!("namespace.{}", namespace_name)
+    }
+}

--- a/controller/lib/src/external_api/workload/model.rs
+++ b/controller/lib/src/external_api/workload/model.rs
@@ -7,6 +7,8 @@ pub enum WorkloadError {
     NameAlreadyExists(String),
     JsonToWorkload(String),
     WorkloadToJson(String),
+    NamespaceService,
+    NamespaceNotFound,
 }
 
 impl WorkloadError {
@@ -25,6 +27,11 @@ impl WorkloadError {
             WorkloadError::WorkloadToJson(err) => HttpResponse::InternalServerError().body(
                 format!("Error while converting the workload to JSON: {}", err),
             ),
+            WorkloadError::NamespaceService => HttpResponse::InternalServerError()
+                .body("Cannot create a NamespaceService instance"),
+            WorkloadError::NamespaceNotFound => {
+                HttpResponse::NotFound().body("Namespace not found")
+            }
         }
     }
 }
@@ -82,7 +89,7 @@ impl WorkloadVector {
         WorkloadVector { workloads }
     }
     pub fn to_http(&self) -> HttpResponse {
-        match serde_json::to_string(&self) {
+        match serde_json::to_string(&self.workloads) {
             Ok(json) => HttpResponse::Ok().body(json),
             Err(err) => HttpResponse::InternalServerError().body(format!(
                 "Error while converting the workload to json: {}",


### PR DESCRIPTION
# Overall explanation of our work :

We implemented routes for managing workloads:
 feat: add workload controller

Add routes and routes handler for namespace.  
Controller use namespace service.

- /namespace/ (GET) : Get all namespace
- /namespace  (PUT) : Create a new namespace
- /namespace/<namespace_name>/<workload_id> (DELETE) : Delete a namespace
- /namespace/<namespace_name>/<workload_id> (GET) : Get a namespace by name
- /namespace/<namespace_name>/<workload_id> (PATCH) : Update a namespace

# Architecture

The code is divided into two parts :

## Service
It implements all the logic to interact with etcd ( insert , retrieve ...)
##  Controller
It contains the routes and the functions they call

A service can load and use other services , in our case NamespaceService use EtcdService.
The controller use NamespaceService as middleware functions. NamespaceService is also used in WorkloadService to check if namespace exist.
