### PR TITLE
feat: (controller) implement node status update

### DIFF
--- a/controller/lib/src/external_api/instance/mod.rs
+++ b/controller/lib/src/external_api/instance/mod.rs
@@ -1,4 +1,4 @@
 pub mod controller;
 mod filter;
-mod model;
-mod service;
+pub mod model;
+pub mod service;

--- a/controller/lib/src/external_api/instance/service.rs
+++ b/controller/lib/src/external_api/instance/service.rs
@@ -135,7 +135,7 @@ impl InstanceService {
     ///
     /// * `this`: the method is called on the `this` object. Used to handle threads.
     /// * `instance`: The instance to schedule
-    fn schedule_instance(this: Arc<Mutex<Self>>, mut instance: Instance) {
+    pub fn schedule_instance(this: Arc<Mutex<Self>>, mut instance: Instance) {
         //Spawn a thread to start the instance
         tokio::spawn(async move {
             loop {

--- a/controller/lib/src/external_api/mod.rs
+++ b/controller/lib/src/external_api/mod.rs
@@ -1,5 +1,5 @@
 pub mod generic;
-mod instance;
+pub mod instance;
 pub mod interface;
 mod namespace;
 mod workload;

--- a/controller/lib/src/internal_api/interface.rs
+++ b/controller/lib/src/internal_api/interface.rs
@@ -5,15 +5,25 @@ use log::info;
 use proto::controller::node_service_server::NodeServiceServer;
 use tonic::transport::Server;
 
+#[derive(Debug)]
+pub enum InternalAPIInterfaceError {
+    NodeControllerError(super::node::controller::NodeControllerError),
+}
+
 pub struct InternalAPIInterface {}
 
 impl InternalAPIInterface {
-    pub async fn new(address: SocketAddr) -> Self {
+    pub fn new(address: SocketAddr, etcd_address: SocketAddr, grpc_address: String) -> Self {
         info!("Starting gRPC server listening on {}", address);
 
         tokio::spawn(async move {
             Server::builder()
-                .add_service(NodeServiceServer::new(NodeController::default()))
+                .add_service(NodeServiceServer::new(
+                    NodeController::new(&etcd_address, &grpc_address)
+                        .await
+                        .map_err(InternalAPIInterfaceError::NodeControllerError)
+                        .unwrap(),
+                ))
                 .serve(address)
                 .await
                 .unwrap();

--- a/controller/lib/src/internal_api/node/controller.rs
+++ b/controller/lib/src/internal_api/node/controller.rs
@@ -1,42 +1,77 @@
-use log::info;
-use tonic::{Request, Response, Status, Streaming};
+use log::{error, info};
+use std::sync::Arc;
+use std::{fmt::Display, net::SocketAddr};
+use tokio::sync::Mutex;
+use tonic::{Code, Request, Response, Status, Streaming};
 
-use proto::controller::NodeStatus;
+use super::service::NodeService;
 
-use proto::controller::node_service_server::NodeService;
+#[derive(Debug)]
+pub enum NodeControllerError {
+    NodeServiceError(super::service::NodeServiceError),
+}
 
-use super::service::update_node_status;
+impl Display for NodeControllerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeControllerError::NodeServiceError(err) => {
+                write!(f, "NodeServiceError: {}", err)
+            }
+        }
+    }
+}
 
-#[derive(Debug, Default)]
-pub struct NodeController {}
+pub struct NodeController {
+    node_service: Arc<Mutex<NodeService>>,
+}
+
+impl NodeController {
+    pub async fn new(
+        etcd_address: &SocketAddr,
+        grpc_address: &str,
+    ) -> Result<Self, NodeControllerError> {
+        Ok(NodeController {
+            node_service: Arc::new(Mutex::new(
+                NodeService::new(etcd_address, grpc_address)
+                    .await
+                    .map_err(NodeControllerError::NodeServiceError)?,
+            )),
+        })
+    }
+}
 
 #[tonic::async_trait]
-impl NodeService for NodeController {
+impl proto::controller::node_service_server::NodeService for NodeController {
     async fn update_node_status(
         &self,
-        request: Request<Streaming<NodeStatus>>,
+        request: Request<Streaming<proto::controller::NodeStatus>>,
     ) -> Result<Response<()>, Status> {
-        let remote_address = request.remote_addr().unwrap();
+        let remote_address = if let Some(remote_address) = request.remote_addr() {
+            remote_address.to_string()
+        } else {
+            error!("\"update_node_status\" Failed to get remote address");
+            "Error getting remote address".to_string()
+        };
 
         info!(
             "{} \"update_node_status\" streaming initiated",
-            remote_address.clone()
+            remote_address
         );
 
-        let mut stream = request.into_inner();
+        let stream = request.into_inner();
 
-        while let Some(node_status) = stream.message().await.unwrap() {
-            info!(
-                "{} \"update_node_status\" received chunk",
-                remote_address.clone()
-            );
-            update_node_status(node_status).unwrap();
-        }
-
-        info!(
-            "{} \"update_node_status\" streaming closed",
-            remote_address.clone()
-        );
+        self.node_service
+            .clone()
+            .lock()
+            .await
+            .update_node_status(stream, remote_address)
+            .await
+            .map_err(|err| {
+                Status::new(
+                    Code::Internal,
+                    NodeControllerError::NodeServiceError(err).to_string(),
+                )
+            })?;
 
         Ok(Response::new(()))
     }

--- a/controller/lib/src/internal_api/node/controller.rs
+++ b/controller/lib/src/internal_api/node/controller.rs
@@ -21,6 +21,11 @@ impl Display for NodeControllerError {
     }
 }
 
+/// Handles gRPC requests from the scheduler for the node service.
+///
+/// Properties:
+///
+/// * `node_service`: An instance of the NodeService that will implement the logic.
 pub struct NodeController {
     node_service: Arc<Mutex<NodeService>>,
 }
@@ -42,6 +47,15 @@ impl NodeController {
 
 #[tonic::async_trait]
 impl proto::controller::node_service_server::NodeService for NodeController {
+    /// It receives the stream sent by the scheduler and updates the persistent storage with the new node status
+    ///
+    /// # Arguments:
+    ///
+    /// * `request`: The stream of node status updates
+    ///
+    /// # Returns:
+    ///
+    /// A Result<Response<()>, Status>
     async fn update_node_status(
         &self,
         request: Request<Streaming<proto::controller::NodeStatus>>,

--- a/controller/lib/src/internal_api/node/mod.rs
+++ b/controller/lib/src/internal_api/node/mod.rs
@@ -1,2 +1,3 @@
 pub mod controller;
+mod model;
 mod service;

--- a/controller/lib/src/internal_api/node/model.rs
+++ b/controller/lib/src/internal_api/node/model.rs
@@ -1,0 +1,62 @@
+use proto::controller::NodeState;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+pub struct NodeStatus {
+    pub id: String,
+    pub state: NodeState,
+    pub status_description: String,
+    pub resource: Option<Resource>,
+    pub instances: Vec<InstanceIdentifier>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Resource {
+    pub limit: Option<ResourceSummary>,
+    pub usage: Option<ResourceSummary>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ResourceSummary {
+    pub cpu: u64,
+    pub memory: u64,
+    pub disk: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct InstanceIdentifier {
+    pub id: String,
+}
+
+impl PartialEq for InstanceIdentifier {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl From<proto::controller::NodeStatus> for NodeStatus {
+    fn from(node_status: proto::controller::NodeStatus) -> Self {
+        NodeStatus {
+            id: node_status.id,
+            state: NodeState::from_i32(node_status.state).unwrap_or(NodeState::Failing),
+            status_description: node_status.status_description,
+            resource: node_status.resource.map(|resource| Resource {
+                limit: resource.limit.map(|resource_summary| ResourceSummary {
+                    cpu: resource_summary.cpu,
+                    memory: resource_summary.memory,
+                    disk: resource_summary.disk,
+                }),
+                usage: resource.usage.map(|resource_summary| ResourceSummary {
+                    cpu: resource_summary.cpu,
+                    memory: resource_summary.memory,
+                    disk: resource_summary.disk,
+                }),
+            }),
+            instances: node_status
+                .instances
+                .into_iter()
+                .map(|instance| InstanceIdentifier { id: instance.id })
+                .collect(),
+        }
+    }
+}

--- a/controller/lib/src/internal_api/node/model.rs
+++ b/controller/lib/src/internal_api/node/model.rs
@@ -1,6 +1,15 @@
 use proto::controller::NodeState;
 use serde::{Deserialize, Serialize};
 
+/// `NodeStatus` is a structure that holds the status of a node registered in the cluster.
+///
+/// Properties:
+///
+/// * `id`: The id of the node.
+/// * `state`: The current life state of the node.
+/// * `status_description`: A text containing details on the status.
+/// * `resource`: The resource used by the node.
+/// * `instances`: A list of instances that are running on the node.
 #[derive(Deserialize, Serialize)]
 pub struct NodeStatus {
     pub id: String,
@@ -10,12 +19,25 @@ pub struct NodeStatus {
     pub instances: Vec<InstanceIdentifier>,
 }
 
+/// `Resource` is a structure that holds information about the resource used by the node.
+///
+/// Properties:
+///
+/// * `limit`: The maximum amount of resources that this node is allowed to use.
+/// * `usage`: The amount of resources currently being used by the node.
 #[derive(Deserialize, Serialize)]
 pub struct Resource {
     pub limit: Option<ResourceSummary>,
     pub usage: Option<ResourceSummary>,
 }
 
+/// `ResourceSummary` is a structure that holds information about physical resources.
+///
+/// Properties:
+///
+/// * `cpu`: A number in milliCPU that represents a CPU.
+/// * `memory`: A number in bytes that represents a memory space.
+/// * `disk`: A number in bytes that represents a disk space.
 #[derive(Deserialize, Serialize)]
 pub struct ResourceSummary {
     pub cpu: u64,

--- a/controller/lib/src/internal_api/node/service.rs
+++ b/controller/lib/src/internal_api/node/service.rs
@@ -60,6 +60,17 @@ impl NodeService {
         })
     }
 
+    /// It receives a stream of `NodeStatus` messages from the scheduler, updates the node's status in etcd,
+    /// and reschedules any instances that were running on the node if the stream is closed.
+    ///
+    /// Arguments:
+    ///
+    /// * `stream`: The stream of messages received from the scheduler.
+    /// * `remote_address`: The address of the scheduler gRPC server that is sending the status update.
+    ///
+    /// Returns:
+    ///
+    /// A `Result` with an `Ok` value of `()` or an `Err` value of `NodeServiceError`.
     pub async fn update_node_status(
         &mut self,
         mut stream: Streaming<proto::controller::NodeStatus>,

--- a/controller/lib/src/internal_api/node/service.rs
+++ b/controller/lib/src/internal_api/node/service.rs
@@ -1,7 +1,115 @@
-use std::fmt::Error;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
 
-use proto::controller::NodeStatus;
+use log::info;
+use tokio::sync::Mutex;
+use tokio::time;
+use tonic::Streaming;
 
-pub fn update_node_status(_node_status: NodeStatus) -> Result<(), Error> {
-    Ok(())
+use crate::etcd::EtcdClient;
+use crate::internal_api::node::model::InstanceIdentifier;
+
+use super::super::super::external_api::instance::{
+    model::Instance, model::InstanceError, service::InstanceService,
+};
+use super::model::NodeStatus;
+
+#[derive(Debug)]
+pub enum NodeServiceError {
+    EtcdError(etcd_client::Error),
+    SerdeError(serde_json::Error),
+    StreamingClosed(tonic::Status),
+    InstanceServiceError(InstanceError),
+}
+
+impl std::fmt::Display for NodeServiceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeServiceError::EtcdError(err) => write!(f, "EtcdError: {}", err),
+            NodeServiceError::SerdeError(err) => write!(f, "SerdeError: {}", err),
+            NodeServiceError::InstanceServiceError(_) => {
+                write!(f, "InstanceServiceError")
+            }
+            NodeServiceError::StreamingClosed(err) => {
+                write!(f, "StreamingClosed: {}", err)
+            }
+        }
+    }
+}
+
+pub struct NodeService {
+    etcd_interface: EtcdClient,
+    instance_service: Arc<Mutex<InstanceService>>,
+}
+
+impl NodeService {
+    pub async fn new(
+        etcd_address: &SocketAddr,
+        grpc_address: &str,
+    ) -> Result<Self, NodeServiceError> {
+        Ok(NodeService {
+            etcd_interface: EtcdClient::new(etcd_address.to_string())
+                .await
+                .map_err(NodeServiceError::EtcdError)?,
+            instance_service: Arc::new(Mutex::new(
+                InstanceService::new(grpc_address, etcd_address)
+                    .await
+                    .map_err(NodeServiceError::InstanceServiceError)?,
+            )),
+        })
+    }
+
+    pub async fn update_node_status(
+        &mut self,
+        mut stream: Streaming<proto::controller::NodeStatus>,
+        remote_address: String,
+    ) -> Result<(), NodeServiceError> {
+        let mut last_instances: Vec<Instance> = vec![];
+
+        while let Some(node_status) = stream
+            .message()
+            .await
+            .map_err(NodeServiceError::StreamingClosed)?
+        {
+            info!("{} \"update_node_status\" received chunk", remote_address);
+
+            let node_status = NodeStatus::from(node_status);
+
+            self.etcd_interface
+                .put(
+                    &node_status.id,
+                    &serde_json::to_string(&node_status).map_err(NodeServiceError::SerdeError)?,
+                )
+                .await
+                .map_err(NodeServiceError::EtcdError)?;
+
+            let objects = self.etcd_interface.get_all().await.unwrap_or_default();
+
+            for object in objects {
+                if let Ok(instance) = serde_json::from_str::<Instance>(&object) {
+                    if node_status.instances.contains(&InstanceIdentifier {
+                        id: instance.clone().id,
+                    }) {
+                        last_instances.push(instance);
+                    }
+                }
+            }
+        }
+
+        info!(
+            "{} \"update_node_status\" streaming closed, rescheduling instances",
+            remote_address.clone()
+        );
+
+        for instance in last_instances {
+            InstanceService::schedule_instance(self.instance_service.clone(), instance)
+        }
+
+        //Delete Node after 5 min
+        time::sleep(Duration::from_secs(300)).await;
+        self.etcd_interface.delete(&remote_address).await;
+
+        Ok(())
+    }
 }

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -13,7 +13,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let config: config::KudoControllerConfig = confy::load_path("controller.conf")?;
 
     // gRPC Server
-    internal_api::interface::InternalAPIInterface::new(config.internal_api.grpc_server_addr).await;
+    internal_api::interface::InternalAPIInterface::new(
+        config.internal_api.grpc_server_addr,
+        config.external_api.etcd_address,
+        config.internal_api.grpc_client_addr.clone(),
+    );
 
     // HTTP Server
     external_api::interface::ExternalAPIInterface::new(

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .type_attribute(
+            "controller.NodeState",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
             "controller.InstanceState",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )


### PR DESCRIPTION
## Overall explanation of your work :

I implemented the `NodeStatusUpdate` service in the gRPC server from the `InternalAPI`. This services handles all `Node` updates received from the **scheduler**.

## Tasks lists :

- [x] Implement `node_status_update`