### PR TITLE
feat(network): Add multinode capabilities

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod instance;
 pub mod node;
+pub mod node_ip;
 pub mod port;
 pub mod utils;

--- a/network/src/node/request.rs
+++ b/network/src/node/request.rs
@@ -1,18 +1,23 @@
 use cidr::Ipv4Inet;
 
+use crate::node_ip::NodeIp;
+
 // Setup
 pub struct SetupNodeRequest {
     /// Unique identifier of the node. This identifier is used to create a bridge interface
     pub node_id: String,
     /// Composed of the node ip and a mask
     pub node_ip_cidr: Ipv4Inet,
+    /// Nodes already in the cluster
+    pub nodes_ips: Vec<NodeRequest>,
 }
 
 impl SetupNodeRequest {
-    pub fn new(node_id: String, node_ip_cidr: Ipv4Inet) -> Self {
+    pub fn new(node_id: String, node_ip_cidr: Ipv4Inet, nodes_ips: Vec<NodeRequest>) -> Self {
         Self {
             node_id,
             node_ip_cidr,
+            nodes_ips,
         }
     }
 }
@@ -24,6 +29,17 @@ pub struct SetupIptablesRequest {
 impl SetupIptablesRequest {
     pub fn new(node_id: String) -> Self {
         Self { node_id }
+    }
+}
+
+pub struct NodeRequest {
+    pub node_id: String,
+    pub nodes_ips: NodeIp,
+}
+
+impl NodeRequest {
+    pub fn new(node_id: String, nodes_ips: NodeIp) -> Self {
+        Self { node_id, nodes_ips }
     }
 }
 

--- a/network/src/node_ip/mod.rs
+++ b/network/src/node_ip/mod.rs
@@ -1,0 +1,16 @@
+use cidr::Ipv4Inet;
+use std::net::Ipv4Addr;
+
+pub struct NodeIp {
+    pub cluster_ip_cidr: Ipv4Inet,
+    pub external_ip_addr: Ipv4Addr,
+}
+
+impl NodeIp {
+    pub fn new(cluster_ip_cidr: Ipv4Inet, external_ip_addr: Ipv4Addr) -> Self {
+        Self {
+            cluster_ip_cidr,
+            external_ip_addr,
+        }
+    }
+}

--- a/network/src/utils/mod.rs
+++ b/network/src/utils/mod.rs
@@ -8,7 +8,7 @@ use crate::error::KudoNetworkError;
 
 const IFACE_MAX_SIZE: usize = 12;
 
-pub(crate) fn bridge_name(node_id: String) -> String {
+pub fn bridge_name(node_id: String) -> String {
     format!("kbr{}", &node_id[..min(IFACE_MAX_SIZE, node_id.len())])
 }
 


### PR DESCRIPTION
This PR defines multinode support.

It allows :

- [X] Setting up NAT/PAT rules to redirect traffic between nodes of the same cluster
- [X] Cleaning up useless iptables when a node leave the cluster

The documentation has also been updated.