### PR TITLE
feat: add node routes

### DIFF
--- a/controller/lib/src/external_api/interface.rs
+++ b/controller/lib/src/external_api/interface.rs
@@ -1,5 +1,5 @@
 use super::namespace;
-use super::{instance, workload};
+use super::{instance, node, workload};
 use actix_web::middleware::Logger;
 use actix_web::{web, App, HttpResponse, HttpServer};
 use log::info;
@@ -34,6 +34,7 @@ impl ExternalAPIInterface {
                 .service(workload::controller::WorkloadController {}.services())
                 .service(namespace::controller::NamespaceController {}.services())
                 .service(instance::controller::InstanceController {}.services())
+                .service(node::controller::NodeController {}.services())
                 .wrap(Logger::default())
         })
         .workers(num_workers)

--- a/controller/lib/src/external_api/mod.rs
+++ b/controller/lib/src/external_api/mod.rs
@@ -2,4 +2,5 @@ pub mod generic;
 pub mod instance;
 pub mod interface;
 mod namespace;
+pub mod node;
 mod workload;

--- a/controller/lib/src/external_api/node/controller.rs
+++ b/controller/lib/src/external_api/node/controller.rs
@@ -1,0 +1,82 @@
+use crate::external_api::{generic::model::Pagination, interface::ActixAppState};
+use actix_web::{http::StatusCode, web, HttpResponse, Responder, Scope};
+
+use super::{model::NodeError, service::NodeService};
+
+pub struct NodeController {}
+
+impl NodeController {
+    pub fn services(&self) -> Scope {
+        web::scope("/node")
+            .service(web::resource("").route(web::get().to(NodeController::get_all_nodes)))
+            .service(web::resource("/{node_id}").route(web::get().to(NodeController::get_node)))
+    }
+
+    /// It gets a node, and return it if it exists
+    ///
+    /// # Arguments:
+    ///
+    /// * id`: The node id to get
+    ///
+    /// # Returns:
+    ///
+    /// A HttpResponse with the node if it exists, or a 404 error if it doesn't.
+
+    pub async fn get_node(id: web::Path<String>, data: web::Data<ActixAppState>) -> impl Responder {
+        let mut node_service = NodeService::new(data.etcd_address)
+            .await
+            .map_err(|err| {
+                HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Error creating node service, {:?}", err))
+            })
+            .unwrap();
+        match node_service.get_node(&id).await {
+            Ok(node) => {
+                HttpResponse::build(StatusCode::OK).body(serde_json::to_string(&node).unwrap())
+            }
+            Err(err) => match err {
+                NodeError::NodeNotFound => {
+                    HttpResponse::build(StatusCode::NOT_FOUND).body("Node not found")
+                }
+                _ => HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body("Internal Server Error"),
+            },
+        }
+    }
+
+    /// `get_all_nodes` is an async function that return all nodes from etcd
+    /// # Description:
+    /// * Get all nodes inside the cluster
+    /// # Arguments:
+    ///
+    /// * `pagination`: The limit and offset used to paginate the vector of nodes
+    /// # Returns:
+    /// An HTTP response with the vector of nodes
+    pub async fn get_all_nodes(
+        pagination: Option<web::Query<Pagination>>,
+        data: web::Data<ActixAppState>,
+    ) -> impl Responder {
+        let mut node_service = NodeService::new(data.etcd_address)
+            .await
+            .map_err(|err| {
+                HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(format!("Error creating node service, {:?}", err))
+            })
+            .unwrap();
+        match pagination {
+            Some(pagination) => {
+                let nodes = node_service
+                    .get_all_nodes(pagination.limit, pagination.offset)
+                    .await;
+                web::Json(nodes)
+            }
+            None => {
+                let nodes = node_service.get_all_nodes(0, 0).await;
+                web::Json(nodes)
+            }
+        }
+
+        // let nodes = node_service.get_all_nodes().await;
+        // web::Json(nodes)
+    }
+}

--- a/controller/lib/src/external_api/node/mod.rs
+++ b/controller/lib/src/external_api/node/mod.rs
@@ -1,0 +1,3 @@
+pub mod controller;
+pub mod model;
+pub mod service;

--- a/controller/lib/src/external_api/node/model.rs
+++ b/controller/lib/src/external_api/node/model.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+
+use super::super::instance::model::Instance;
+
+#[derive(Debug)]
+pub enum NodeError {
+    NodeNotFound,
+    Etcd(String),
+    SerdeError(serde_json::Error),
+}
+
+impl ToString for NodeError {
+    fn to_string(&self) -> String {
+        match self {
+            NodeError::Etcd(err) => {
+                format!("ETCD Error : {}", err)
+            }
+            NodeError::SerdeError(err) => {
+                format!("Serde Error : {}", err)
+            }
+            &NodeError::NodeNotFound => "Node not found".to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct NodeDTO {
+    pub id: String,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+
+pub struct ResourceSummary {
+    pub cpu: i64,
+    pub memory: i64,
+    pub disk: i64,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct Resource {
+    pub usage: ResourceSummary,
+    pub limit: ResourceSummary,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub enum NodeState {
+    REGISTERING = 0,
+    REGISTERED = 1,
+    UNREGISTERING = 2,
+    UNREGISTERED = 3,
+    FAILING = 4,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct NodeStatus {
+    pub id: String,
+    pub state: NodeState,
+    pub status_description: String,
+    pub resource: Resource,
+    pub instances: Vec<Instance>,
+}

--- a/controller/lib/src/external_api/node/service.rs
+++ b/controller/lib/src/external_api/node/service.rs
@@ -1,0 +1,80 @@
+use std::net::SocketAddr;
+
+use crate::{etcd::EtcdClient, external_api::generic::filter::FilterService};
+
+use super::model::{NodeError, NodeStatus};
+
+pub struct NodeService {
+    pub etcd_service: EtcdClient,
+    pub filter_service: FilterService,
+}
+
+impl NodeService {
+    pub async fn new(etcd_address: SocketAddr) -> Result<Self, NodeError> {
+        let etcd_service = EtcdClient::new(etcd_address.to_string())
+            .await
+            .map_err(|err| NodeError::Etcd(err.to_string()))?;
+
+        Ok(Self {
+            etcd_service,
+            filter_service: FilterService::new(),
+        })
+    }
+
+    /// It gets a node from etcd, and if it exists return it to the caller.
+    ///
+    /// # Arguments:
+    ///
+    /// * `node_id`: The node id to get
+    ///
+    /// # Returns:
+    ///
+    /// A Result<NodeStatus, NodeError>
+
+    pub async fn get_node(&mut self, node_id: &str) -> Result<NodeStatus, NodeError> {
+        match self.etcd_service.get(node_id).await {
+            Some(node) => {
+                let node_status: NodeStatus = serde_json::from_str(&node)
+                    .map_err(NodeError::SerdeError)
+                    .unwrap();
+                Ok(node_status)
+            }
+            None => Err(NodeError::NodeNotFound),
+        }
+    }
+
+    /// This function get all nodes from etcd and slice the result by limit and offset
+    /// If there is an error , the function always return an empty vector
+    /// # Arguments:
+    ///
+    /// * `limit`: The number of nodes to return.
+    /// * `offset`: The offset of the nodes to be returned
+    ///
+    /// # Returns:
+    ///
+    /// A vector of nodes
+
+    pub async fn get_all_nodes(&mut self, limit: u32, offset: u32) -> Vec<NodeStatus> {
+        let mut nodes = Vec::new();
+        match self.etcd_service.get_all().await {
+            Some(keys) => {
+                for node in keys {
+                    if let Ok(node) = serde_json::from_str(&node) {
+                        nodes.push(node);
+                    }
+                }
+                if offset > 0 {
+                    match self.filter_service.offset(&nodes, offset) {
+                        Ok(new_nodes) => nodes = new_nodes,
+                        Err(_) => return Vec::new(),
+                    }
+                }
+                if limit > 0 {
+                    nodes = self.filter_service.limit(&nodes, limit);
+                }
+                nodes
+            }
+            None => nodes,
+        }
+    }
+}


### PR DESCRIPTION
# Overall explanation of our work

Implementation of routes to get nodes :

- [x] GET /node : Retrieve all nodes saved with pagination
- [x] GET/node/<node_id> : Retrive one node with his id

## Architecture

Code is split in 3 parts:
- **Service** : Implement all the logic to retrive nodes
- **Controller** : It contains all routes and the functions called
- **Model** : Contains all the models used by the two others