### PR TITLE
Fix : Fixing workload & namespace service

### DIFF
--- a/controller/lib/src/external_api/namespace/service.rs
+++ b/controller/lib/src/external_api/namespace/service.rs
@@ -100,6 +100,7 @@ impl NamespaceService {
         };
         let json = serde_json::to_string(&namespace)
             .map_err(|err| NamespaceError::NamespaceToJson(err.to_string()))?;
+        self.delete_namespace(namespace_name).await;
         self.etcd_service
             .put(&new_id, &json)
             .await

--- a/controller/lib/src/external_api/workload/service.rs
+++ b/controller/lib/src/external_api/workload/service.rs
@@ -181,6 +181,7 @@ impl WorkloadService {
         };
         let json = serde_json::to_string(&workload)
             .map_err(|err| WorkloadError::WorkloadToJson(err.to_string()))?;
+        self.delete_workload(workload_name, namespace).await;
         self.etcd_service
             .put(&new_id, &json)
             .await


### PR DESCRIPTION
 - When removing a namespace, remove all workloads in
 - When updating name (PATCH route), remove older value